### PR TITLE
Caliper Event: edx.course.enrollment.deactivated

### DIFF
--- a/openedx/features/caliper_tracking/caliper_config.py
+++ b/openedx/features/caliper_tracking/caliper_config.py
@@ -1,6 +1,7 @@
 from openedx.features.caliper_tracking.transformers.bookmark_transformers import edx_bookmark_listed
 from openedx.features.caliper_tracking.transformers.enrollment_transformers import edx_course_enrollment_activated
 from openedx.features.caliper_tracking.transformers.navigation_transformers import edx_ui_lms_link_clicked
+from openedx.features.caliper_tracking.transformers.enrollment_transformers import edx_course_enrollment_deactivated
 
 """
 Mapping of events to their transformer functions
@@ -10,4 +11,5 @@ EVENT_MAPPING = {
     'edx.bookmark.listed': edx_bookmark_listed,
     'edx.ui.lms.link_clicked': edx_ui_lms_link_clicked,
     'edx.course.enrollment.activated': edx_course_enrollment_activated,
+    'edx.course.enrollment.deactivated': edx_course_enrollment_deactivated,
 }

--- a/openedx/features/caliper_tracking/transformers/enrollment_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/enrollment_transformers.py
@@ -14,3 +14,21 @@ def edx_course_enrollment_activated(current_event, caliper_event):
     })
     caliper_event['actor']['type'] = 'Person'
     return caliper_event
+    
+
+def edx_course_enrollment_deactivated(current_event, caliper_event):
+    """
+    Caliper specific log for edX course unenrollment
+    """
+    caliper_object = {
+        'course_id': current_event['context']['course_id'],
+        'user_id': caliper_event['user_id'],
+        'mode': current_event['event']['mode']
+    }
+    caliper_event.update({
+        'object': caliper_object,
+        'type': 'Enrollment',
+        'action': 'Deactivated'
+    })
+    caliper_event['actor']['type'] = 'Person'
+    return caliper_event

--- a/openedx/features/caliper_tracking/utils.py
+++ b/openedx/features/caliper_tracking/utils.py
@@ -1,3 +1,11 @@
 """
 Utils required in transformers
 """
+from opaque_keys.edx.locator import CourseLocator
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+
+def get_course(course_key):
+    # TODO not finalized
+    course_id = CourseLocator.from_string(course_key)
+    return CourseOverview.objects.get(id=course_id)


### PR DESCRIPTION
**Trello Link:** https://trello.com/c/yB8cbHnM

**Description:** _When a student unenrolls from a course, the server emits an edx.course.enrollment.deactivated event. The following PR makes a caliper specific log for that event _

**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
