### PR TITLE
Implement edx.ui.lms.link_clicked transformer with currently availa…

### DIFF
--- a/openedx/features/caliper_tracking/caliper_config.py
+++ b/openedx/features/caliper_tracking/caliper_config.py
@@ -1,5 +1,6 @@
 from openedx.features.caliper_tracking.transformers.bookmark_transformers import edx_bookmark_listed
 from openedx.features.caliper_tracking.transformers.enrollment_transformers import edx_course_enrollment_activated
+from openedx.features.caliper_tracking.transformers.navigation_transformers import edx_ui_lms_link_clicked
 
 """
 Mapping of events to their transformer functions
@@ -7,5 +8,6 @@ Mapping of events to their transformer functions
 
 EVENT_MAPPING = {
     'edx.bookmark.listed': edx_bookmark_listed,
+    'edx.ui.lms.link_clicked': edx_ui_lms_link_clicked,
     'edx.course.enrollment.activated': edx_course_enrollment_activated,
 }

--- a/openedx/features/caliper_tracking/transformers/navigation_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/navigation_transformers.py
@@ -1,0 +1,31 @@
+"""
+Transformers for all the navigation events
+"""
+
+import json
+
+
+def edx_ui_lms_link_clicked(current_event, caliper_event):
+    """
+    This trannsformer uses current_event to generate caliper_event
+    with currently available data.
+
+    :param current_event: default event log generated.
+    :param caliper_event: caliper_event log having some basic attributes.
+    :return: updated caliper_event.
+    """
+    
+    caliper_event['type'] = 'NavigationEvent'
+    caliper_event['action'] = 'NavigateTo'
+    caliper_event['actor']['type'] = 'Person'
+
+    # 'event' attribute in current_event has json dumped data. So to obtain
+    # target_url , convert it into json object.
+    current_event_details = json.loads(current_event['event'])
+
+    caliper_event['object'] = {
+        'id': current_event_details['target_url'],
+        'type': 'WebPage',
+    }
+
+    return caliper_event


### PR DESCRIPTION
This transformer transforms current_event to required caliper_event with currently available data.

**Trello Link:** [edx.ui.lms.link_clicked](https://trello.com/c/Xl1WZOon/2-edxuilmslinkclicked)

**Description:** edx.ui.lms.link_clicked transformer implemented with currently available fields.

Currently missing attributes :-

- `name`, `description` and `dateCreated` in `object` key.
- `edApp`
- `session` and inner attributes.
- `membership` and inner attributes.
- `group` and inner attributes.

**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
