### PR TITLE
add caliper transformer for edx.course.enrollment.mode_changed event

### DIFF
--- a/openedx/features/caliper_tracking/caliper_config.py
+++ b/openedx/features/caliper_tracking/caliper_config.py
@@ -1,7 +1,10 @@
 from openedx.features.caliper_tracking.transformers.bookmark_transformers import edx_bookmark_listed
-from openedx.features.caliper_tracking.transformers.enrollment_transformers import edx_course_enrollment_activated
 from openedx.features.caliper_tracking.transformers.navigation_transformers import edx_ui_lms_link_clicked
-from openedx.features.caliper_tracking.transformers.enrollment_transformers import edx_course_enrollment_deactivated
+from openedx.features.caliper_tracking.transformers.enrollment_transformers import (
+    edx_course_enrollment_activated,
+    edx_course_enrollment_mode_changed,
+    edx_course_enrollment_deactivated
+)
 
 """
 Mapping of events to their transformer functions
@@ -12,4 +15,5 @@ EVENT_MAPPING = {
     'edx.ui.lms.link_clicked': edx_ui_lms_link_clicked,
     'edx.course.enrollment.activated': edx_course_enrollment_activated,
     'edx.course.enrollment.deactivated': edx_course_enrollment_deactivated,
+    'edx.course.enrollment.mode_changed': edx_course_enrollment_mode_changed,
 }

--- a/openedx/features/caliper_tracking/transformers/enrollment_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/enrollment_transformers.py
@@ -26,7 +26,12 @@ def edx_course_enrollment_activated(current_event, caliper_event):
 
 def edx_course_enrollment_deactivated(current_event, caliper_event):
     """
-    Caliper specific log for edX course unenrollment
+    The server emits an enrollment.deactivated event when the student's
+    enrollment is cancelled.
+
+    :param current_event: default log
+    :param caliper_event: log containing both basic and default attribute
+    :return: final created log
     """
     caliper_object = {
         'course_id': current_event['context']['course_id'],
@@ -38,5 +43,25 @@ def edx_course_enrollment_deactivated(current_event, caliper_event):
         'type': 'Enrollment',
         'action': 'Deactivated'
     })
+    caliper_event['actor']['type'] = 'Person'
+    return caliper_event
+
+
+def edx_course_enrollment_mode_changed(current_event, caliper_event):
+    """
+    The server emits an enrollment.mode_changed event when the student's
+    enrollment mode is changed.
+
+    :param current_event: default log
+    :param caliper_event: log containing both basic and default attribute
+    :return: final created log
+    """
+    caliper_event.update({
+        'type': 'Enrollment',
+        'action': 'Mode_Changed',
+        'object': current_event['event'],
+        'course_id': current_event['context']['course_id']
+    })
+
     caliper_event['actor']['type'] = 'Person'
     return caliper_event


### PR DESCRIPTION
**Trello Link:** [edx.course.enrollment.mode_changed event](https://trello.com/c/VE0jW7iS/55-enrollment-event-edxcourseenrollmentmodechanged)

**Description:** 
- edx.course.enrollment.mode_changed event transformer implemented with currently available fields.
- added docstring in enrollment deactivated function
- converted multiple imports into one, for enrollment events

**Currently Unavailable Attributes:** dateCreated, dateModified, courseNumber, academicSession, name

**Checks before merge:**

- [x] Reviewed
- [x] Commits squashed
