### PR TITLE
edx_course_enrollment_activated evet trsansformer

### DIFF
--- a/openedx/features/caliper_tracking/transformers/enrollment_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/enrollment_transformers.py
@@ -4,13 +4,21 @@ Transformers for all course related events.
 
 
 def edx_course_enrollment_activated(current_event, caliper_event):
+    """
+    When a student enrolls in a course, the server emits an edx.course.enrollment.activated event.
+
+    :param current_event: default log
+    :param caliper_event: log containing both basic and default attribute
+    :return: final created log
+    """
     caliper_event.update({
         'ip': current_event['ip'],
         'object': current_event['event'],
         'status': current_event['event']['mode'],
         'page': current_event['page'],
         'type': 'Membership',
-        'action': 'Activated'
+        'action': 'Activated',
+        'course_id': current_event['event']['course_id']
     })
     caliper_event['actor']['type'] = 'Person'
     return caliper_event


### PR DESCRIPTION
Add course_id field and docstring in edx_course_enrollment_activated event transformer

**Trello Link:** [link](https://trello.com/c/zHVxuG6e/21-enrollment-events-edxcourseenrollmentactivated)

**Description:** Add new field (course_id ) in the previous version. As now course_id has been removed from the calliper_event coming from base_transformer.

**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
