### PR TITLE
Imporved imports on package level for caliper transformers

### DIFF
--- a/openedx/features/caliper_tracking/caliper_config.py
+++ b/openedx/features/caliper_tracking/caliper_config.py
@@ -1,21 +1,14 @@
-from openedx.features.caliper_tracking.transformers.bookmark_transformers import edx_bookmark_listed
-from openedx.features.caliper_tracking.transformers.navigation_transformers import edx_ui_lms_link_clicked
-from openedx.features.caliper_tracking.transformers.enrollment_transformers import (
-    edx_course_enrollment_activated,
-    edx_course_enrollment_mode_changed,
-    edx_course_enrollment_deactivated,
-    edx_course_enrollment_upgrade_clicked
-)
+from openedx.features.caliper_tracking import transformers as ctf
 
 """
 Mapping of events to their transformer functions
 """
 
 EVENT_MAPPING = {
-    'edx.bookmark.listed': edx_bookmark_listed,
-    'edx.ui.lms.link_clicked': edx_ui_lms_link_clicked,
-    'edx.course.enrollment.activated': edx_course_enrollment_activated,
-    'edx.course.enrollment.deactivated': edx_course_enrollment_deactivated,
-    'edx.course.enrollment.mode_changed': edx_course_enrollment_mode_changed,
-    'edx.course.enrollment.upgrade.clicked': edx_course_enrollment_upgrade_clicked,
+    'edx.bookmark.listed': ctf.edx_bookmark_listed,
+    'edx.ui.lms.link_clicked': ctf.edx_ui_lms_link_clicked,
+    'edx.course.enrollment.activated': ctf.edx_course_enrollment_activated,
+    'edx.course.enrollment.deactivated': ctf.edx_course_enrollment_deactivated,
+    'edx.course.enrollment.mode_changed': ctf.edx_course_enrollment_mode_changed,
+    'edx.course.enrollment.upgrade.clicked': ctf.edx_course_enrollment_upgrade_clicked,
 }

--- a/openedx/features/caliper_tracking/transformers/__init__.py
+++ b/openedx/features/caliper_tracking/transformers/__init__.py
@@ -1,0 +1,9 @@
+"""
+Exposes transformers functions.
+"""
+from .bookmark_transformers import edx_bookmark_listed
+from .navigation_transformers import edx_ui_lms_link_clicked
+from .enrollment_transformers import (
+    edx_course_enrollment_activated, edx_course_enrollment_mode_changed, edx_course_enrollment_deactivated,
+    edx_course_enrollment_upgrade_clicked
+)


### PR DESCRIPTION
**Trello Link:** [here](https://trello.com/c/9LnV02WR/57-improve-imports-of-transformer-functionsl)
**Description:** As we were having too long and too many imports in `caliper_config.py` so I've tried to shift these in package `__init__.py`

**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
