### PR TITLE
edx.cohort.user_added event

### DIFF
--- a/openedx/features/caliper_tracking/caliper_config.py
+++ b/openedx/features/caliper_tracking/caliper_config.py
@@ -71,6 +71,7 @@ EVENT_MAPPING = {
         ctf.edx_course_enrollment_upgrade_succeeded,
     'edx.course.student_notes.notes_page_viewed':
         ctf.edx_course_student_notes_notes_page_viewed,
+    'edx.cohort.user_added': ctf.edx_cohort_user_added,
     'edx.forum.thread.voted': ctf.edx_forum_thread_voted,
     'edx.forum.response.voted': ctf.edx_forum_response_voted,
     'openassessmentblock.submit_feedback_on_assessments':

--- a/openedx/features/caliper_tracking/tests/current/edx.cohort.user_added.json
+++ b/openedx/features/caliper_tracking/tests/current/edx.cohort.user_added.json
@@ -1,0 +1,26 @@
+{
+  "accept_language": "en-US,en;q=0.9",
+  "agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+  "context": {
+    "course_id": "course-v1:Arbisoft+1+1",
+    "course_user_tags": {},
+    "org_id": "Arbisoft",
+    "path": "/courses/course-v1:Arbisoft+1+1/cohorts/1/add",
+    "user_id": 13
+  },
+  "event": {
+    "cohort_id": 1,
+    "cohort_name": "Test Cohort",
+    "user_id": 2
+  },
+  "event_source": "server",
+  "event_type": "edx.cohort.user_added",
+  "host": "48ca736c86e8",
+  "ip": "172.19.0.1",
+  "name": "edx.cohort.user_added",
+  "page": null,
+  "referer": "http://localhost:18000/courses/course-v1:Arbisoft+1+1/instructor",
+  "session": "d6e5ba806f327a72206fbe497376c126",
+  "time": "2018-10-17T14:54:42.756040+00:00",
+  "username": "osamaarshad"
+}

--- a/openedx/features/caliper_tracking/tests/expected/edx.cohort.user_added.json
+++ b/openedx/features/caliper_tracking/tests/expected/edx.cohort.user_added.json
@@ -1,0 +1,53 @@
+{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+  "action": "Added",
+  "actor": {
+    "id": "http://localhost:18000/u/osamaarshad",
+    "name": "osamaarshad",
+    "type": "Person"
+  },
+  "eventTime": "2018-10-17T14:54:42.756Z",
+  "extensions": {
+    "extra_fields": {
+      "accept_language": "en-US,en;q=0.9",
+      "agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+      "course_id": "course-v1:Arbisoft+1+1",
+      "course_user_tags": {},
+      "event_source": "server",
+      "event_type": "edx.cohort.user_added",
+      "host": "48ca736c86e8",
+      "ip": "172.19.0.1",
+      "org_id": "Arbisoft",
+      "page": null,
+      "path": "/courses/course-v1:Arbisoft+1+1/cohorts/1/add",
+      "session": "d6e5ba806f327a72206fbe497376c126",
+      "user_id": 13
+    }
+  },
+  "id": "urn:uuid:d4618c23-d612-4709-8d9a-478d87808067",
+  "object": {
+    "id": "http://localhost:18000/courses/course-v1:Arbisoft+1+1/instructor#view-cohort_management",
+    "member": {
+      "extensions": {
+        "user_id": 2
+      },
+      "id": "http://localhost:18000/u/honor",
+      "name": "honor",
+      "type": "Person"
+    },
+    "organization": {
+      "extensions": {
+        "cohort_id": 1
+      },
+      "id": "http://localhost:18000/courses/course-v1:Arbisoft+1+1/instructor#view-cohort_management",
+      "name": "Test Cohort",
+      "type": "Group"
+    },
+    "type": "Membership"
+  },
+  "referrer": {
+    "id": "http://localhost:18000/courses/course-v1:Arbisoft+1+1/instructor",
+    "type": "WebPage"
+  },
+  "type": "Event"
+}

--- a/openedx/features/caliper_tracking/tests/tests.py
+++ b/openedx/features/caliper_tracking/tests/tests.py
@@ -1,7 +1,7 @@
 """
 This module contains the test cases for caliper_tracking application
 """
-
+import mock
 import json
 import os
 from datetime import datetime
@@ -25,7 +25,12 @@ class CaliperTransformationTestCase(TestCase):
 
     maxDiff = None
 
-    def test_caliper_transformers(self):
+    @mock.patch(
+        'openedx.features.caliper_tracking.utils.get_username_from_user_id',
+        return_value='honor',
+        autospec=True
+    )
+    def test_caliper_transformers(self, mock_function):
         test_files = [file for file in os.listdir(
             '{}current/'.format(TEST_DIR_PATH)) if file.endswith(".json")]
 

--- a/openedx/features/caliper_tracking/transformers/__init__.py
+++ b/openedx/features/caliper_tracking/transformers/__init__.py
@@ -100,3 +100,6 @@ from .peer_instruction_transformers import (
     ubc_peer_instruction_revised_submitted,
     ubc_peer_instruction_original_submitted,
 )
+from .cohort_transformers import (
+    edx_cohort_user_added,
+)

--- a/openedx/features/caliper_tracking/transformers/bookmark_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/bookmark_transformers.py
@@ -16,6 +16,7 @@ def edx_bookmark_listed(current_event, caliper_event):
     :param caliper_event: caliper_event log having some basic attributes.
     :return: updated caliper_event.
     """
+
     caliper_event.update({
         'type': 'NavigationEvent',
         'action': 'NavigatedTo',

--- a/openedx/features/caliper_tracking/transformers/cohort_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/cohort_transformers.py
@@ -1,0 +1,76 @@
+"""
+Transformers for all cohort related events.
+"""
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+
+from openedx.features.caliper_tracking import utils
+
+
+def edx_cohort_user_added(current_event, caliper_event):
+    """
+    When new user is added to cohort.
+
+    :param current_event: default log
+    :param caliper_event: log containing both basic and default attribute
+    :return: final created log
+    """
+
+    username = utils.get_username_from_user_id(
+        current_event['event']['user_id'])
+
+    cohort_page_link = '{instructor_page}#view-cohort_management'.format(
+        instructor_page=current_event['referer'])
+
+    user_link = '{lms_url}{profile_link}'.format(
+        lms_url=settings.LMS_ROOT_URL,
+        profile_link=str(reverse(
+            'learner_profile',
+            kwargs={'username': username}
+        ))
+    )
+
+    caliper_object = {
+        'id': cohort_page_link,
+        'member': {
+            'extensions': {
+                'user_id': current_event['event']['user_id']
+            },
+            'id': user_link,
+            'name': username,
+            'type': 'Person'
+        },
+        'organization': {
+            'extensions': {
+                'cohort_id': current_event['event']['cohort_id']
+            },
+            'id': cohort_page_link,
+            'name': current_event['event']['cohort_name'],
+            'type': 'Group'
+        },
+        'type': 'Membership'
+    }
+
+    caliper_event.update({
+        'type': 'Event',
+        'action': 'Added',
+        'object': caliper_object,
+    })
+
+    caliper_event['actor'].update({
+        'type': 'Person',
+        'name': current_event['username']
+    })
+
+    caliper_event['referrer'].update({
+        'type': 'WebPage'
+    })
+
+    caliper_event['extensions']['extra_fields'].update({
+        'ip': current_event['ip'],
+        'course_id': current_event['context']['course_id'],
+        'course_user_tags': current_event['context']['course_user_tags']
+    })
+
+    return caliper_event

--- a/openedx/features/caliper_tracking/utils.py
+++ b/openedx/features/caliper_tracking/utils.py
@@ -2,6 +2,7 @@
 Utils required in transformers
 """
 from dateutil.parser import parse
+from django.contrib.auth import get_user_model
 
 UTC_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 
@@ -25,3 +26,14 @@ def convert_datetime(current_datetime):
         utc_datetime.strftime(UTC_DATETIME_FORMAT)[:-3], 'Z'
     )
     return formatted_datetime
+
+
+def get_username_from_user_id(user_id):
+    """
+    @param : user_id
+    :return: username from the given user_id.
+    """
+
+    User = get_user_model()
+    user = User.objects.get(id=user_id)
+    return str(user.username)


### PR DESCRIPTION
**Trello Link:** _https://trello.com/c/RqYtOLdg/50-cohort-event-edxcohortuseradded_

**Description:** _When a user is added to a cohort, the server emits an edx.cohort.user_added event. Members of the course team can add users to cohorts individually or by uploading a .csv file of student cohort assignments. The system automatically adds a user to the default cohort or a cohort included in the course’s auto_cohort_groups setting if a user who has not yet been assigned to a cohort accesses course content._

**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
