### PR TITLE
Add current and expected jsons with transformer for edx.team.searched

### DIFF
--- a/openedx/features/caliper_tracking/caliper_config.py
+++ b/openedx/features/caliper_tracking/caliper_config.py
@@ -129,4 +129,5 @@ EVENT_MAPPING = {
     'edx.special_exam.timed.attempt.deleted':
         ctf.edx_special_exam_timed_attempt_deleted,
     'oppia.exploration.completed': ctf.oppia_exploration_completed,
+    'edx.team.searched': ctf.edx_team_searched,
 }

--- a/openedx/features/caliper_tracking/tests/current/edx.team.searched.json
+++ b/openedx/features/caliper_tracking/tests/current/edx.team.searched.json
@@ -1,0 +1,25 @@
+{
+  "accept_language": "en-US,en;q=0.9",
+  "agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.80 Safari/537.36",
+  "context": {
+    "course_id": "course-v1:edx+CS0110+2014_T",
+    "org_id": "edx",
+    "path": "/api/team/v0/teams/",
+    "user_id": 2
+  },
+  "event": {
+    "number_of_results": 0,
+    "search_text": "hello",
+    "topic_id": "Topic1ID"
+  },
+  "event_source": "server",
+  "event_type": "edx.team.searched",
+  "host": "8c3b43aa7b1b",
+  "ip": "172.18.0.1",
+  "name": "edx.team.searched",
+  "page": null,
+  "referer": "http://localhost:18000/courses/course-v1:edx+CS0110+2014_T/teams/",
+  "session": "8b5aaa43369a0d612918005f1a65f27f",
+  "time": "2018-12-26T12:57:21.978410+00:00",
+  "username": "honor"
+}

--- a/openedx/features/caliper_tracking/tests/expected/edx.team.searched.json
+++ b/openedx/features/caliper_tracking/tests/expected/edx.team.searched.json
@@ -1,0 +1,41 @@
+{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+  "action": "Searched",
+  "actor": {
+    "id": "http://localhost:18000/u/honor",
+    "name": "honor",
+    "type": "Person"
+  },
+  "eventTime": "2018-12-26T12:57:21.978Z",
+  "extensions": {
+    "extra_fields": {
+      "accept_language": "en-US,en;q=0.9",
+      "agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.80 Safari/537.36",
+      "event_source": "server",
+      "event_type": "edx.team.searched",
+      "host": "8c3b43aa7b1b",
+      "ip": "172.18.0.1",
+      "page": null,
+      "path": "/api/team/v0/teams/",
+      "session": "8b5aaa43369a0d612918005f1a65f27f",
+      "user_id": 2
+    }
+  },
+  "id": "urn:uuid:d4618c23-d612-4709-8d9a-478d87808067",
+  "object": {
+    "extensions": {
+      "course_id": "course-v1:edx+CS0110+2014_T",
+      "number_of_results": 0,
+      "org_id": "edx",
+      "search_text": "hello",
+      "topic_id": "Topic1ID"
+    },
+    "id": "http://localhost:18000/courses/course-v1:edx+CS0110+2014_T/teams/",
+    "type": "Group"
+  },
+  "referrer": {
+    "id": "http://localhost:18000/courses/course-v1:edx+CS0110+2014_T/teams/",
+    "type": "WebPage"
+  },
+  "type": "Event"
+}

--- a/openedx/features/caliper_tracking/transformers/__init__.py
+++ b/openedx/features/caliper_tracking/transformers/__init__.py
@@ -120,6 +120,7 @@ from .team_transformers import (
     edx_team_page_viewed,
     edx_team_changed,
     edx_team_learner_added,
+    edx_team_searched,
 )
 from .cohort_transformers import (
     edx_cohort_user_added,

--- a/openedx/features/caliper_tracking/transformers/team_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/team_transformers.py
@@ -153,3 +153,46 @@ def edx_team_changed(current_event, caliper_event):
     })
 
     return caliper_event
+
+
+def edx_team_searched(current_event, caliper_event):
+    """
+    When a user performs a search for teams from the topic view under the
+    Teams page of the courseware, the server emits an edx.team.searched event.
+
+    :param current_event: default event log generated.
+    :param caliper_event: caliper_event log having some basic attributes.
+    :return: updated caliper_event.
+    """
+
+    object_extensions = current_event['event']
+
+    object_extensions.update({
+        'course_id': current_event['context']['course_id'],
+        'org_id': caliper_event['extensions']['extra_fields'].pop('org_id'),
+    })
+
+    caliper_object = {
+        'id': current_event['referer'],
+        'type': 'Group',
+        'extensions': object_extensions
+    }
+
+    caliper_event.update({
+        'type': 'Event',
+        'action': 'Searched',
+        'object': caliper_object
+    })
+
+    caliper_event['referrer']['type'] = 'WebPage'
+
+    caliper_event['actor'].update({
+        'name': current_event['username'],
+        'type': 'Person'
+    })
+
+    caliper_event['extensions']['extra_fields'].update({
+        'ip': current_event['ip'],
+    })
+
+    return caliper_event


### PR DESCRIPTION
**Trello Link:** _https://trello.com/c/NvpxudQH/118-teams-related-event-edxteamsearched_

**Description:** _When a user performs a search for teams from the topic view under the Teams page of the courseware, the server emits an edx.team.searched event.
_

**Checks before merge:**

- [x] Reviewed
- [x] Commits squashed
