### PR TITLE
Video hide cc menu event

### DIFF
--- a/openedx/features/caliper_tracking/caliper_config.py
+++ b/openedx/features/caliper_tracking/caliper_config.py
@@ -46,6 +46,7 @@ EVENT_MAPPING = {
     'save_problem_success': ctf.save_problem_success,
     'play_video': ctf.play_video,
     'hide_transcript': ctf.hide_transcript,
+    'video_hide_cc_menu': ctf.video_hide_cc_menu,
     'edx.forum.thread.created': ctf.edx_forum_thread_created,
     'openassessmentblock.get_peer_submission':
         ctf.openassessmentblock_get_peer_submission,

--- a/openedx/features/caliper_tracking/tests/current/video_hide_cc_menu.json
+++ b/openedx/features/caliper_tracking/tests/current/video_hide_cc_menu.json
@@ -1,0 +1,21 @@
+{
+  "username":"verified",
+  "context":{
+    "user_id":8,
+    "org_id":"ABC",
+    "course_id":"course-v1:ABC+CS103x+2018_T2",
+    "path":"/event"
+  },
+  "event_source":"browser",
+  "name":"edx.video.language_menu.hidden",
+  "ip":"172.18.0.1",
+  "agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+  "event":"{\"duration\": 141, \"code\": \"3_yD_cEKoCk\", \"id\": \"e5bd3f7c2a3b4ea78ce01dd990d1b0f1\"}",
+  "host":"8433fad63981",
+  "session":"d6db2ece54e8cf1943c19b68518896d1",
+  "referer":"http://localhost:18000/courses/course-v1:ABC+CS103x+2018_T2/courseware/6d50d03de20a44e690dde8dbd7467917/ab7879d6d17743dcb4f7fdd96949dfe6/2?activate_block_id=block-v1%3AABC%2BCS103x%2B2018_T2%2Btype%40vertical%2Bblock%400e505063819941d0885bf504b5572ec7",
+  "accept_language":"en-US,en;q=0.9",
+  "time":"2018-10-23T09:04:49.446201+00:00",
+  "page":"http://localhost:18000/courses/course-v1:ABC+CS103x+2018_T2/courseware/6d50d03de20a44e690dde8dbd7467917/ab7879d6d17743dcb4f7fdd96949dfe6/2?activate_block_id=block-v1%3AABC%2BCS103x%2B2018_T2%2Btype%40vertical%2Bblock%400e505063819941d0885bf504b5572ec7",
+  "event_type":"video_hide_cc_menu"
+}

--- a/openedx/features/caliper_tracking/tests/expected/video_hide_cc_menu.json
+++ b/openedx/features/caliper_tracking/tests/expected/video_hide_cc_menu.json
@@ -1,0 +1,42 @@
+{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+  "action": "Hid",
+  "actor": {
+    "id": "http://localhost:18000/u/verified",
+    "name": "verified",
+    "type": "Person"
+  },
+  "eventTime": "2018-10-23T09:04:49.446Z",
+  "extensions": {
+    "extra_fields": {
+      "accept_language": "en-US,en;q=0.9",
+      "agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+      "course_id": "course-v1:ABC+CS103x+2018_T2",
+      "event_source": "browser",
+      "event_type": "video_hide_cc_menu",
+      "host": "8433fad63981",
+      "ip": "172.18.0.1",
+      "name": "edx.video.language_menu.hidden",
+      "org_id": "ABC",
+      "page": "http://localhost:18000/courses/course-v1:ABC+CS103x+2018_T2/courseware/6d50d03de20a44e690dde8dbd7467917/ab7879d6d17743dcb4f7fdd96949dfe6/2?activate_block_id=block-v1%3AABC%2BCS103x%2B2018_T2%2Btype%40vertical%2Bblock%400e505063819941d0885bf504b5572ec7",
+      "path": "/event",
+      "session": "d6db2ece54e8cf1943c19b68518896d1",
+      "user_id": 8
+    }
+  },
+  "id": "urn:uuid:849b00d0-ab84-4169-8ae7-2f537eeaf56c",
+  "object": {
+    "duration": "PT2M21S",
+    "extensions": {
+      "code": "3_yD_cEKoCk",
+      "id": "e5bd3f7c2a3b4ea78ce01dd990d1b0f1"
+    },
+    "id": "http://localhost:18000/courses/course-v1:ABC+CS103x+2018_T2/courseware/6d50d03de20a44e690dde8dbd7467917/ab7879d6d17743dcb4f7fdd96949dfe6/2?activate_block_id=block-v1%3AABC%2BCS103x%2B2018_T2%2Btype%40vertical%2Bblock%400e505063819941d0885bf504b5572ec7",
+    "type": "Frame"
+  },
+  "referrer": {
+    "id": "http://localhost:18000/courses/course-v1:ABC+CS103x+2018_T2/courseware/6d50d03de20a44e690dde8dbd7467917/ab7879d6d17743dcb4f7fdd96949dfe6/2?activate_block_id=block-v1%3AABC%2BCS103x%2B2018_T2%2Btype%40vertical%2Bblock%400e505063819941d0885bf504b5572ec7",
+    "type": "WebPage"
+  },
+  "type": "Event"
+}

--- a/openedx/features/caliper_tracking/transformers/__init__.py
+++ b/openedx/features/caliper_tracking/transformers/__init__.py
@@ -53,6 +53,7 @@ from .video_transformers import (
     edx_video_closed_captions_hidden,
     show_transcript,
     hide_transcript,
+    video_hide_cc_menu,
 )
 from .forum_transformers import (
     edx_forum_response_created,

--- a/openedx/features/caliper_tracking/transformers/video_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/video_transformers.py
@@ -434,3 +434,40 @@ def show_transcript(current_event, caliper_event):
     })
     caliper_event['referrer']['type'] = 'WebPage'
     return caliper_event
+
+
+def video_hide_cc_menu(current_event, caliper_event):
+    """
+    When a user closes the Language Menu for a video that has transcripts in multiple languages, the browser emits a
+    video_hide_cc_menu event.
+
+    :param current_event: default log
+    :param caliper_event: log containing both basic and default attribute
+    :return: final created log
+    """
+    current_event_details = json.loads(current_event['event'])
+    caliper_event.update({
+        'action': 'Hid',
+        'type': 'Event',
+        'object': {
+            'duration': duration_isoformat(
+                timedelta(seconds=current_event_details['duration'])),
+            'extensions': {
+                'code': current_event_details['code'],
+                'id': current_event_details['id']
+            },
+            'id': current_event['referer'],
+            'type': 'Frame'
+        }
+    })
+    caliper_event['actor'].update({
+        'name': current_event['username'],
+        'type': 'Person'
+    })
+    caliper_event['extensions']['extra_fields'].update({
+        'course_id': current_event['context']['course_id'],
+        'ip': current_event['ip'],
+        'name': current_event['name']
+    })
+    caliper_event['referrer']['type'] = 'WebPage'
+    return caliper_event


### PR DESCRIPTION
**Trello Link:**  [here](https://trello.com/c/qaDcPz0J/106-video-interaction-event-videohideccmenu-edxvideolanguagemenuhidden)

**Description:** When a user closes the Language Menu for a video that has transcripts in multiple languages, the browser emits a video_hide_cc_menu event.

**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
