### PR TITLE
Bug fix in edx.course.tool.accesse event

### DIFF
--- a/openedx/features/caliper_tracking/tests/expected/edx.course.tool.accessed.json
+++ b/openedx/features/caliper_tracking/tests/expected/edx.course.tool.accessed.json
@@ -1,7 +1,7 @@
 {
     "eventTime":"2018-12-10T06:37:32.332Z",
-    "action": "Used",
-    "type": "ToolUseEvent",
+    "action": "NavigatedTo",
+    "type": "NavigationEvent",
     "referrer":{
         "id":"http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/course/",
         "type": "WebPage"

--- a/openedx/features/caliper_tracking/transformers/navigation_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/navigation_transformers.py
@@ -57,8 +57,8 @@ def edx_course_tool_accessed(current_event, caliper_event):
     }
 
     caliper_event.update({
-        'type': 'ToolUseEvent',
-        'action': 'Used',
+        'type': 'NavigationEvent',
+        'action': 'NavigatedTo',
         'object': caliper_object,
     })
 


### PR DESCRIPTION
Changed event type and action as webPage (old action) is not supported under ToolUseEvent.