### PR TITLE
Bug fix in problem_graded event

### DIFF
--- a/openedx/features/caliper_tracking/tests/expected/problem_graded.json
+++ b/openedx/features/caliper_tracking/tests/expected/problem_graded.json
@@ -32,7 +32,7 @@
       ]
     },
     "id": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/courseware/1414ffd5143b4b508f739b563ab468b7/workflow/",
-    "type": "Assessment"
+    "type": "Attempt"
   },
   "referrer": {
     "id": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/courseware/1414ffd5143b4b508f739b563ab468b7/workflow/",

--- a/openedx/features/caliper_tracking/transformers/problem_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/problem_transformers.py
@@ -93,7 +93,7 @@ def problem_graded(current_event, caliper_event):
         'extensions': {
             'event': current_event['event']
         },
-        'type': 'Assessment'
+        'type': 'Attempt'
     }
     caliper_event.update({
         'action': 'Graded',


### PR DESCRIPTION
Change object type as Assessment (old object) is not supported under GradeEvent.
_trello_link:_ https://trello.com/c/qobqOPRV/29-problem-interaction-event-problemgraded