### PR TITLE
Bug fix in edx.bookmark.removed event

### DIFF
--- a/openedx/features/caliper_tracking/tests/expected/edx.bookmark.removed.json
+++ b/openedx/features/caliper_tracking/tests/expected/edx.bookmark.removed.json
@@ -31,7 +31,7 @@
             "course_id": "course-v1:ar+CS113x+2018_T3"
         },
         "id": "http://localhost:18000/courses/course-v1:ar+CS113x+2018_T3/courseware/61c5a01d2255496f88a367be5ad525db/766d16ae8c734d6a8304f1fad5d1d088/1?activate_block_id=block-v1%3Aar%2BCS113x%2B2018_T3%2Btype%40vertical%2Bblock%40ba4ee5b3905747208702f465275733b6",
-        "type": "Bookmark"
+        "type": "BookmarkAnnotation"
     },
     "referrer": {
         "id": "http://localhost:18000/courses/course-v1:ar+CS113x+2018_T3/courseware/61c5a01d2255496f88a367be5ad525db/766d16ae8c734d6a8304f1fad5d1d088/1?activate_block_id=block-v1%3Aar%2BCS113x%2B2018_T3%2Btype%40vertical%2Bblock%40ba4ee5b3905747208702f465275733b6",

--- a/openedx/features/caliper_tracking/transformers/bookmark_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/bookmark_transformers.py
@@ -137,7 +137,7 @@ def edx_bookmark_removed(current_event, caliper_event):
     })
     caliper_event['object'] = {
         'id':  current_event.get('referer'),
-        'type': 'Bookmark',
+        'type': 'BookmarkAnnotation',
         'extensions': current_event['event']
     }
     return caliper_event


### PR DESCRIPTION
Change object type because object of type "Bookmark" does not exist.

**Trello Link:** _https://trello.com/c/a20tgnJH/61-bookmark-events-edxbookmarkremoved_