### PR TITLE
Change structure of play_video event

### DIFF
--- a/openedx/features/caliper_tracking/tests/expected/play_video.json
+++ b/openedx/features/caliper_tracking/tests/expected/play_video.json
@@ -27,7 +27,6 @@
     "object": {
         "duration": "PT3M15S",
         "extensions": {
-            "currentTime": "PT0.026738S",
             "id": "0b9e39477cf34507a7a48f74be381fdd",
             "code": "b7xgknqkQk8"
         },
@@ -37,6 +36,11 @@
     "referrer": {
         "id": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40vertical_0270f6de40fc",
         "type": "WebPage"
+    },
+    "target": {
+        "currentTime": "PT0.026738S",
+        "id": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40vertical_0270f6de40fc",
+        "type": "MediaLocation"
     },
     "type": "MediaEvent"
 }

--- a/openedx/features/caliper_tracking/transformers/video_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/video_transformers.py
@@ -141,9 +141,19 @@ def play_video(current_event, caliper_event):
     :param caliper_event: log containing both basic and default attribute
     :return: final created log
     """
+
+    event_info = json.loads(current_event['event'])
+
     caliper_event.update({
         'action': 'Started',
-        'type': 'MediaEvent'
+        'type': 'MediaEvent',
+        'target': {
+            'currentTime': duration_isoformat(timedelta(
+                seconds=event_info['currentTime']
+            )),
+            'id': current_event['referer'],
+            'type': 'MediaLocation'
+        }
     })
 
     caliper_event['extensions']['extra_fields'].update({
@@ -158,8 +168,6 @@ def play_video(current_event, caliper_event):
         'type': 'Person'
     })
 
-    event_info = json.loads(current_event['event'])
-
     caliper_event['object'] = {
         'id': current_event.get('referer'),
         'type': 'VideoObject',
@@ -169,9 +177,6 @@ def play_video(current_event, caliper_event):
         'extensions': {
             'id': event_info.get('id'),
             'code': event_info.get('code'),
-            'currentTime': duration_isoformat(timedelta(
-                seconds=event_info.get('currentTime')
-            ))
         }
     }
     return caliper_event


### PR DESCRIPTION
- Remove currentTime from extensions as it should be a part of "target" key.
- Add "target" key with a currentTime.

**Trello Link:** _https://trello.com/c/zAo1c0KO/41-video-interaction-event-playvideo-edxvideoplayed_

