### PR TITLE
move currentTime into target attribute

### DIFF
--- a/openedx/features/caliper_tracking/tests/expected/speed_change_video.json
+++ b/openedx/features/caliper_tracking/tests/expected/speed_change_video.json
@@ -28,13 +28,17 @@
         "duration": "PT2M21S",
         "extensions": {
             "code": "3_yD_cEKoCk",
-            "current_time": "PT5.171946S",
             "id": "5e9b65b2ce6b4b6eb0a1bd894e06b810",
             "new_speed": "0.75",
             "old_speed": "1.50"
         },
         "id": "http://localhost:18000/courses/course-v1:ar+CS113x+2018_T3/courseware/61c5a01d2255496f88a367be5ad525db/766d16ae8c734d6a8304f1fad5d1d088/1",
         "type": "VideoObject"
+    },
+    "target": {
+        "id": "http://localhost:18000/courses/course-v1:ar+CS113x+2018_T3/courseware/61c5a01d2255496f88a367be5ad525db/766d16ae8c734d6a8304f1fad5d1d088/1",
+        "type": "MediaLocation",
+        "currentTime": "PT5.171946S"
     },
     "referrer": {
         "id": "http://localhost:18000/courses/course-v1:ar+CS113x+2018_T3/courseware/61c5a01d2255496f88a367be5ad525db/766d16ae8c734d6a8304f1fad5d1d088/1",

--- a/openedx/features/caliper_tracking/transformers/video_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/video_transformers.py
@@ -122,13 +122,14 @@ def edx_video_speed_changed(current_event, caliper_event):
             seconds=event_info.pop('duration')
         )),
     }
-    object_extensions = {
-        'current_time': duration_isoformat(timedelta(
+    caliper_event['target'] = {
+        'id': current_event['referer'],
+        'type': 'MediaLocation',
+        'currentTime': duration_isoformat(timedelta(
             seconds=event_info.pop('current_time')
         ))
     }
-    object_extensions.update(event_info)
-    caliper_event['object']['extensions'] = object_extensions
+    caliper_event['object']['extensions'] = event_info
     return caliper_event
 
 


### PR DESCRIPTION
**Trello Link:** _https://trello.com/c/C3Rq2O26/49-video-interaction-event-speedchangevideo_

**Description:** move currentTime from object extensions to target attribute.

**Checks before merge:**

- [x] Reviewed
- [x] Commits squashed
