### PR TITLE
modified team_url to referer, because team's url gets deleted

### DIFF
--- a/openedx/features/caliper_tracking/tests/expected/edx.team.deleted.json
+++ b/openedx/features/caliper_tracking/tests/expected/edx.team.deleted.json
@@ -28,7 +28,7 @@
     "extensions": {
       "team_id": "check-3429fc5983a84c8c8366a4477b03d91c"
     },
-    "id": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/teams/#teams/Topic1ID/check-3429fc5983a84c8c8366a4477b03d91c",
+    "id": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/teams/",
     "type": "Group"
   },
   "referrer": {

--- a/openedx/features/caliper_tracking/transformers/team_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/team_transformers.py
@@ -117,10 +117,7 @@ def edx_team_deleted(current_event, caliper_event):
     :return: updated caliper_event.
     """
 
-    team_link = utils.get_team_url_from_team_id(
-        current_event['referer'],
-        current_event['event']['team_id']
-    )
+    team_link = current_event['referer']
 
     caliper_object = {
         'extensions': current_event['event'],


### PR DESCRIPTION
**Trello Link:** _https://trello.com/c/bgEsibO7/113-teams-related-event-edxteamdeleted_

**Description:** _Modified team's url to the referer, because once a team is deleted then team's url can't be formed_

**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
