### PR TITLE
Map event key of current event to the object extensions of caliper event

### DIFF
--- a/openedx/features/caliper_tracking/tests/expected/xblock.survey.view_results.json
+++ b/openedx/features/caliper_tracking/tests/expected/xblock.survey.view_results.json
@@ -30,6 +30,7 @@
   },
   "id": "urn:uuid:3fa5fb93-1e64-4695-a953-9842e31b7da9",
   "object": {
+    "extensions": {},
     "id": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/courseware/57cffc9e27e5494aa72444b142cc79fd/da1e0ff2718b471b88ad9a5d5fede8a7/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40c1f57e13fe9d4cc7b7780c8fb5d26ff5",
     "type": "Result"
   },

--- a/openedx/features/caliper_tracking/transformers/xblock_transformers.py
+++ b/openedx/features/caliper_tracking/transformers/xblock_transformers.py
@@ -52,7 +52,8 @@ def xblock_survey_view_results(current_event, caliper_event):
     """
     caliper_object = {
         'id': current_event['referer'],
-        'type': 'Result'
+        'type': 'Result',
+        'extensions': current_event['event']
     }
     caliper_event['extensions']['extra_fields'].update({
         'ip': current_event['ip'],


### PR DESCRIPTION
**Trello Link:** [link](https://trello.com/c/6RQMsM04/48-poll-and-survey-event-xblocksurveyviewresults)

**Description:** 

> 
The server emits an xblock.survey.view_results event when a matrix of survey response percentages is displayed to a user. For surveys that have the Private Results option set to False only, the matrix appears after a user submits survey responses.

**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
