### PR TITLE
Replace contact-form zendesk with UCSD email service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
             sudo mongod --config /etc/mongodb.conf &
             paver test_system -t openedx/features/caliper_tracking/tests/tests.py::CaliperTransformationTestCase::test_caliper_transformers --fasttest --cov-args="-p"
+            paver test_system -t openedx/features/ucsd_features/tests/tests.py --fasttest
 
       - store_artifacts:
           path: test-reports

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -602,3 +602,5 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_c
 ########################## Derive Any Derived Settings  #######################
 
 derive_settings(__name__)
+
+SUPPORT_DESK_EMAILS = ['servicedesk@ucsd.edu']

--- a/lms/templates/support/contact_us.html
+++ b/lms/templates/support/contact_us.html
@@ -33,7 +33,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_j
             'loginQuery': "${login_query() | n, js_escaped_string}",
             'dashboardUrl': "${reverse('dashboard') | n, js_escaped_string}",
             'homepageUrl': "${marketing_link('ROOT') | n, js_escaped_string}",
-            'submitFormUrl': "${reverse('zendesk_proxy_v1') | n, js_escaped_string}",
+            'submitFormUrl': "${reverse('ucsd_support_email') | n, js_escaped_string}",
             'customFields': ${custom_fields | n, dump_js_escaped_json},
             'tags': ${tags | n, dump_js_escaped_json},
             'supportEmail': "${support_email | n, js_escaped_string}",

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -53,6 +53,7 @@ from student import views as student_views
 from student_account import views as student_account_views
 from track import views as track_views
 from util import views as util_views
+from openedx.features.ucsd_features import urls as ucsd_email_urls
 
 if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
     django_autodiscover()
@@ -1081,5 +1082,9 @@ if settings.FEATURES.get('ENABLE_API_DOCS'):
     urlpatterns += [
         url(r'^api-docs/$', get_swagger_view(title='LMS API')),
     ]
+
+urlpatterns += [
+    url(r'^ucsd_email/', include(ucsd_email_urls))
+]
 
 urlpatterns.extend(plugin_urls.get_patterns(plugin_constants.ProjectType.LMS))

--- a/openedx/features/ucsd_features/tests/tests.py
+++ b/openedx/features/ucsd_features/tests/tests.py
@@ -1,0 +1,59 @@
+import json
+import mock
+
+from django.http import HttpResponse
+from django.test import Client
+from django.test import TestCase
+from django.urls import reverse
+
+from rest_framework import status
+
+
+class SupportEmailTestCase(TestCase):
+    """
+    Tests email sending via contact/support form.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super(SupportEmailTestCase, cls).setUpClass()
+        cls.client = Client()
+        cls.send_mail_url = reverse('ucsd_support_email')
+        cls.test_email = {
+            'subject': 'Subject goes here',
+            'comment': {'body': 'here goes the body/details'},
+            'tags': ['LMS'],
+            'requester': {
+                'email': 'edx@example.com',
+                'name': 'edx'
+            },
+            'custom_fields': [{
+                'value': 'course-v1:edX+DemoX+Demo_Course'
+            }]
+        }
+
+    def test_send_email_successful(self):
+        """
+        Make sure email works successfully.
+        """
+        response = self.client.post(self.send_mail_url,
+                                    data=json.dumps(self.test_email),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @mock.patch(
+        'django.test.Client.post', return_value=HttpResponse(
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR
+        ), autospec=True
+    )
+    def test_send_email_fail(self, mock_func):
+        """
+        Make sure email fails successfully.
+        """
+
+        response = self.client.post(self.send_mail_url,
+                                    data=json.dumps(self.test_email),
+                                    content_type='application/json')
+
+        self.assertEqual(response.status_code,
+                         status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/openedx/features/ucsd_features/urls.py
+++ b/openedx/features/ucsd_features/urls.py
@@ -1,0 +1,15 @@
+"""
+Map urls to the relevant view handlers
+"""
+
+from django.conf.urls import url
+from .views import email_support
+
+
+urlpatterns = [
+    url(
+        r'^ucsd_support_email$',
+        email_support,
+        name='ucsd_support_email'
+    )
+]

--- a/openedx/features/ucsd_features/views.py
+++ b/openedx/features/ucsd_features/views.py
@@ -1,0 +1,42 @@
+import json
+
+from django.core.mail import send_mail
+from django.conf import settings
+from django.views.decorators.http import require_http_methods
+from django.http import HttpResponse
+from rest_framework import status
+
+email_template = '''
+    Course : {course}
+    Name: {name}
+    Email : {email}
+    
+    {body}
+    '''
+
+
+@require_http_methods(["POST"])
+def email_support(request):
+    """
+    A View that will send user support (contact-form) emails to a specific
+    account.
+    """
+
+    body = json.loads(request.body)
+    subject = body['subject']
+
+    data = {
+        'name': body['requester']['name'],
+        'email': body['requester']['email'],
+        'body': body['comment']['body'],
+        'course': body['custom_fields'][0]['value']
+    }
+
+    content = email_template.format(**data)
+    response = send_mail(subject, content, settings.DEFAULT_FROM_EMAIL,
+                         settings.SUPPORT_DESK_EMAILS, fail_silently=False)
+
+    if response:
+        return HttpResponse(status=status.HTTP_201_CREATED)
+    else:
+        return HttpResponse(status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
**Trello Link:** _https://trello.com/c/q4i4TUS3/161-send-email-for-contact-us-form-submission-to-servicedeskucsdedu_

**Description:** _A new django-app which sends contact-form data through email to a specific email address_

**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
