### PR TITLE
Add custom backend for google-oauth

### DIFF
--- a/common/djangoapps/third_party_auth/custom_backends.py
+++ b/common/djangoapps/third_party_auth/custom_backends.py
@@ -1,0 +1,48 @@
+from social_core.backends.google import GoogleOAuth2
+
+
+class GoogleOAuth2Backend(GoogleOAuth2):
+
+    def get_user_id(self, details, response):
+        """Use google email as unique id"""
+        if self.setting('USE_UNIQUE_USER_ID', False):
+            if 'sub' in response:
+                return response['sub']
+            else:
+                return response['id']
+        else:
+            return details['email']
+
+    def get_user_details(self, response):
+        """Return user details from Google API account"""
+        if 'email' in response:
+            email = response['email']
+        else:
+            email = ''
+
+        name, given_name, family_name = (
+            response.get('name', ''),
+            response.get('given_name', ''),
+            response.get('family_name', ''),
+        )
+
+        fullname, first_name, last_name = self.get_user_names(
+            name, given_name, family_name
+        )
+        return {
+            'username': email.split('@', 1)[0],
+            'email': email,
+            'fullname': fullname,
+            'first_name': first_name,
+            'last_name': last_name
+        }
+
+    def user_data(self, access_token, *args, **kwargs):
+        """Return user data from Google API"""
+        return self.get_json(
+            'https://www.googleapis.com/oauth2/v3/userinfo',
+            params={
+                'access_token': access_token,
+                'alt': 'json'
+            }
+        )

--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -93,6 +93,6 @@ class ThirdPartyOAuthTestMixinFacebook(object):
 class ThirdPartyOAuthTestMixinGoogle(object):
     """Tests oauth with the Google backend"""
     BACKEND = "google-oauth2"
-    USER_URL = "https://www.googleapis.com/plus/v1/people/me"
+    USER_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
     # In google-oauth2 responses, the "email" field is used as the user's identifier
     UID_FIELD = "email"

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -670,7 +670,7 @@ X_FRAME_OPTIONS = ENV_TOKENS.get('X_FRAME_OPTIONS', X_FRAME_OPTIONS)
 ##### Third-party auth options ################################################
 if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     tmp_backends = ENV_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [
-        'social_core.backends.google.GoogleOAuth2',
+        'third_party_auth.custom_backends.GoogleOAuth2Backend',
         'social_core.backends.linkedin.LinkedinOAuth2',
         'social_core.backends.facebook.FacebookOAuth2',
         'social_core.backends.azuread.AzureADOAuth2',

--- a/lms/envs/bok_choy.env.json
+++ b/lms/envs/bok_choy.env.json
@@ -141,7 +141,7 @@
     "SYSLOG_SERVER": "",
     "TECH_SUPPORT_EMAIL": "technical@example.com",
     "THIRD_PARTY_AUTH_BACKENDS": [
-        "social_core.backends.google.GoogleOAuth2",
+        "third_party_auth.custom_backends.GoogleOAuth2Backend",
         "social_core.backends.linkedin.LinkedinOAuth2",
         "social_core.backends.facebook.FacebookOAuth2",
         "third_party_auth.dummy.DummyBackend",

--- a/lms/envs/bok_choy_docker.env.json
+++ b/lms/envs/bok_choy_docker.env.json
@@ -141,7 +141,7 @@
     "SYSLOG_SERVER": "",
     "TECH_SUPPORT_EMAIL": "technical@example.com",
     "THIRD_PARTY_AUTH_BACKENDS": [
-        "social_core.backends.google.GoogleOAuth2",
+        "third_party_auth.custom_backends.GoogleOAuth2Backend",
         "social_core.backends.linkedin.LinkedinOAuth2",
         "social_core.backends.facebook.FacebookOAuth2",
         "third_party_auth.dummy.DummyBackend",

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -235,7 +235,7 @@ PASSWORD_COMPLEXITY = {}
 FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True
 
 AUTHENTICATION_BACKENDS = [
-    'social_core.backends.google.GoogleOAuth2',
+    'third_party_auth.custom_backends.GoogleOAuth2Backend',
     'social_core.backends.linkedin.LinkedinOAuth2',
     'social_core.backends.facebook.FacebookOAuth2',
     'social_core.backends.azuread.AzureADOAuth2',


### PR DESCRIPTION
A `custom google_oauth` has been added in this PR to replace the `google_oauth` of `social_core_auth`.