### PR TITLE
update caliper version to 11.6

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -176,7 +176,7 @@ numpy==1.6.2
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2      # via django-rest-swagger
-openedx-caliper-tracking==0.11.5
+openedx-caliper-tracking==0.11.6
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4


### PR DESCRIPTION
To replace the version of `openedx-caliper-tracking` app to fetch the latest changes.