### PR TITLE
Tehreem/remove extra ecommerce domain cookie settings

### DIFF
--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -898,5 +898,5 @@ def student_dashboard(request):
     response = render_to_response('dashboard.html', context)
     set_logged_in_cookies(request, response, user)
     response.delete_cookie(
-        ECOMMERCE_TRANSACTION_COOKIE_NAME, domain=settings.ECOMMERCE_COOKIE_DOMAIN)
+        ECOMMERCE_TRANSACTION_COOKIE_NAME, domain=settings.SESSION_COOKIE_DOMAIN)
     return response

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -108,11 +108,6 @@ with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
 
 
-# Authorizenet payment processor set a cookie for dashboard to show pending course purchased dashoard
-# notification. This cookie domain will be used to set and delete that cookie.
-ECOMMERCE_COOKIE_DOMAIN = ENV_TOKENS.get('ECOMMERCE_COOKIE_DOMAIN', None)
-
-
 # STATIC_ROOT specifies the directory where static files are
 # collected
 STATIC_ROOT_BASE = ENV_TOKENS.get('STATIC_ROOT_BASE', None)


### PR DESCRIPTION
**Ticket Link:** _https://edlyio.atlassian.net/secure/RapidBoard.jspa?rapidView=3&projectKey=EDS&modal=detail&selectedIssue=EDS-99_

**Description:** _We were using a new setting variable ECOMMERCE_COOKIE DOMAIN for Authorizenet notification on the LMS side. But our requirement can also be fulfilled with the existing edX setting variable SESSION_COOKIE_DOMAIN._

_So we need to remove ECOMMERCE_COOKIE DOMAIN and use SESSION_COOKIE_DOMAIN instead._

**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
