### PR TITLE
FIX: Double event logs are emitted for login operations

### DIFF
--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -516,17 +516,6 @@ def shim_student_view(view_func, check_logged_in=False):
         else:
             response.content = msg
 
-        if response.status_code == 200:
-            event_name = 'edx.user.login'
-            event_data = {
-                'email': request.POST.get('email'),
-                'remember': request.POST.get('remember'),
-                'username': request.user.username,
-                'user_id': request.user.id
-            }
-            event_data.update(response_dict)
-            tracker.emit(event_name, event_data)
-
 
         # Return the response, preserving the original headers.
         # This is really important, since the student views set cookies


### PR DESCRIPTION
**JIRA Link:** _https://edlyio.atlassian.net/secure/RapidBoard.jspa?rapidView=3&modal=detail&selectedIssue=EDS-108&quickFilter=16_

**Description:** 
_BUG_: Event was being fired from an outer (wrapper) method as well as
inner login method (view)
_FIX_: Remove the code to emit the event from wrapper view.


**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
