### PR TITLE
Use "/tos" instead of "/honor" as "Terms of service and honor" url

### DIFF
--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -845,7 +845,9 @@ class RegistrationFormFactory(object):
             # Translators: This is a legal document users must agree to
             # in order to register a new account.
             terms_label = _(u"Terms of Service and Honor Code")
-            terms_link = marketing_link("HONOR")
+            # [UCSD_CUSTOM] we want to use "tos" page as "HONOR" page
+            # so we will use "/tos" url instead of "/honor"
+            terms_link = marketing_link("TOS")
 
         # Translators: "Terms of Service" is a legal document users must agree to
         # in order to register a new account.


### PR DESCRIPTION
**Story Link:** _https://edlyio.atlassian.net/browse/EDS-126_

**Description:** _Use "/tos" instead of "/honor" as "Terms of service and honor" url on Registration page_


**Checks before merge:**

- [ ] Reviewed
- [ ] Commits squashed
