### PR TITLE
Default Course Image

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -635,3 +635,4 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.CMS, plugin_c
 ########################## Derive Any Derived Settings  #######################
 
 derive_settings(__name__)
+INSTALLED_APPS.append('openedx.features.ucsd_features')

--- a/openedx/features/ucsd_features/signals.py
+++ b/openedx/features/ucsd_features/signals.py
@@ -5,6 +5,7 @@ from django.dispatch import receiver
 from django.db.models.signals import post_save
 
 from lms.djangoapps.verify_student.models import ManualVerification
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from student.models import UserProfile
 
 
@@ -29,3 +30,14 @@ def generate_manual_verification_for_user(sender, instance, created, **kwargs):
         )
     except Exception:  # pylint: disable=broad-except
         logger.error('Error while generating ManualVerification for user: %s', instance.user.email, exc_info=True)
+
+
+@receiver(post_save, sender=CourseOverview)
+def course_image_change(sender, instance, created, **kwargs):
+    """
+    Change the default course image whenever new course is created
+    """
+    if created:
+        if instance.course_image_url.endswith('images_course_image.jpg'):
+            instance.course_image_url = "/static/" + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
+            instance.save()


### PR DESCRIPTION
#### Story Link
[Course images are not loading on QA server](https://edlyio.atlassian.net/browse/EDS-167)

#### PR Description

This PR contains the solution to the default course image issue. Whenever a new course is created edX adds some image path to the course which doesn't exist due to which the user get the 404 error in LMS dashboard. In this PR we have a solution that will replace that path with some valid path.

#### Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Change

#### How to test?

- Set `"DEFAULT_COURSE_ABOUT_IMAGE_URL": "/ucsd-edx-platform/images/course_image.png"` flag in your `lms.env.json` and `cms.env.json`.
- Create a new course from the studio.
- Go to LMS Dashboard and find the course. 
- Check if default image is showing.

#### Checklist before merging:

- [ ] Squased
- [ ] Reviewd