### PR TITLE
Fixed the default course image issue in elasticsearch

### DIFF
--- a/openedx/core/lib/courses.py
+++ b/openedx/core/lib/courses.py
@@ -10,6 +10,7 @@ from six import text_type
 from xmodule.assetstore.assetmgr import AssetManager
 from xmodule.contentstore.content import StaticContent
 from xmodule.contentstore.django import contentstore
+from xmodule.exceptions import NotFoundError
 from xmodule.modulestore.django import modulestore
 
 
@@ -32,8 +33,12 @@ def course_image_url(course, image_key='course_image'):
         url = settings.STATIC_URL + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
     else:
         loc = StaticContent.compute_location(course.id, getattr(course, image_key))
-        url = StaticContent.serialize_asset_key_with_slash(loc)
-
+        try:
+            AssetManager.find(loc)
+        except NotFoundError:
+            url = '/static/' + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
+        else:
+            url = StaticContent.serialize_asset_key_with_slash(loc)
     return url
 
 


### PR DESCRIPTION
#### Story Link
[Default image on courses page no loading via elastic search](https://edlyio.atlassian.net/browse/EDS-227)

#### PR Description
This PR fixes the issue where the default course image is no loading on the courses page on LMS.

#### Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Change

#### How to test?
Create a new course from Studio and reindex it. After go to the LMS courses page and check if course has the default image set.

#### Checklist before merging:

- [x] Squased
- [ ] Reviewd
