### PR TITLE
Remove verified word from unenroll confirmation box

### DIFF
--- a/lms/static/js/dashboard/legacy.js
+++ b/lms/static/js/dashboard/legacy.js
@@ -103,11 +103,11 @@
                  diagAttr['data-track-info'] = gettext('Are you sure you want to unenroll from %(courseName)s ' +
                                                    '(%(courseNumber)s)?');
              } else if (showRefundOption) {
-                 diagAttr['data-track-info'] = gettext('Are you sure you want to unenroll from the verified ' +
+                 diagAttr['data-track-info'] = gettext('Are you sure you want to unenroll from the ' +
                                                    '%(certNameLong)s  track of %(courseName)s  (%(courseNumber)s)?');
                  diagAttr['data-refund-info'] = gettext('You will be refunded the amount you paid.');
              } else {
-                 diagAttr['data-track-info'] = gettext('Are you sure you want to unenroll from the verified ' +
+                 diagAttr['data-track-info'] = gettext('Are you sure you want to unenroll from the ' +
                                                    '%(certNameLong)s track of %(courseName)s (%(courseNumber)s)?');
                  diagAttr['data-refund-info'] = gettext('The refund deadline for this course has passed,' +
                      'so you will not receive a refund.');


### PR DESCRIPTION
The file responsible for unenroll notification box is 
`lms/static/js/dashboard/legacy.js`
First I tried to override that file in theme but it didn't work because of some unknown issues so now I am updating in core edX code.