### PR TITLE
Changed the Post SSO message and username conflict message

### DIFF
--- a/common/djangoapps/student/tests/test_retirement.py
+++ b/common/djangoapps/student/tests/test_retirement.py
@@ -264,7 +264,9 @@ class TestRegisterRetiredUsername(TestCase):
     # The returned message here varies depending on whether a ValidationError -or-
     # an AccountValidationError occurs.
     INVALID_ACCT_ERR_MSG = ('An account with the Public Username', 'already exists.')
-    INVALID_ERR_MSG = ('It looks like', 'belongs to an existing account. Try again with a different username.')
+    INVALID_ERR_MSG = ('It looks like', 'belongs to an existing account. Please use a different public username. '
+                                        'Your email address is still your unique identifier for your account.')
+
 
     def setUp(self):
         super(TestRegisterRetiredUsername, self).setUp()

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -231,12 +231,17 @@
             },
 
             renderAuthWarning: function() {
-                var message = _.sprintf(
-                    gettext('You have successfully signed into %(currentProvider)s, but your %(currentProvider)s' +
-                            ' account does not have a linked %(platformName)s account. To link your accounts,' +
-                            ' sign in now using your %(platformName)s password.'),
-                    {currentProvider: this.currentProvider, platformName: this.platformName}
-                );
+                var message = HtmlUtils.interpolateHtml(
+                        gettext('{paragraphStart}You have successfully signed into {currentProvider}, but your {currentProvider} account does not have a linked {platformName} account.{paragraphEnd}' + // eslint-disable-line max-len
+                        '{blankLine}{paragraphStart}If you already have a {platformName} account, please log in below to link it to your {currentProvider} account.{paragraphEnd}' + // eslint-disable-line max-len
+                        '{blankLine}{paragraphStart}If you do not have a {platformName} account, please click the "Create a {platformName} Account" button.{paragraphEnd}'), { // eslint-disable-line max-len
+                            currentProvider: this.currentProvider,
+                            platformName: this.platformName,
+                            paragraphStart: HtmlUtils.HTML('<p>'),
+                            paragraphEnd: HtmlUtils.HTML('</p>'),
+                            blankLine: HtmlUtils.HTML('<br>')
+                        }
+                    );
 
                 this.clearAuthWarning();
                 this.renderFormFeedback(this.formStatusTpl, {

--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -52,7 +52,8 @@ EMAIL_CONFLICT_MSG = _(
 )
 USERNAME_CONFLICT_MSG = _(
     u"It looks like {username} belongs to an existing account. "
-    u"Try again with a different username."
+    u"Please use a different public username. "
+    u"Your email address is still your unique identifier for your account."
 )
 
 # Translators: This message is shown to users who enter a username/email/password

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -914,7 +914,8 @@ class RegistrationViewValidationErrorTest(ThirdPartyAuthTestMixin, UserAPITestCa
                 "username": [{
                     "user_message": (
                         "It looks like {} belongs to an existing account. "
-                        "Try again with a different username."
+                        "Please use a different public username. "
+                        "Your email address is still your unique identifier for your account."
                     ).format(
                         self.USERNAME
                     )
@@ -2220,7 +2221,8 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 "username": [{
                     "user_message": (
                         "It looks like {} belongs to an existing account. "
-                        "Try again with a different username."
+                        "Please use a different public username. "
+                        "Your email address is still your unique identifier for your account."
                     ).format(
                         self.USERNAME
                     )
@@ -2255,7 +2257,8 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 "username": [{
                     "user_message": (
                         "It looks like {} belongs to an existing account. "
-                        "Try again with a different username."
+                        "Please use a different public username. "
+                        "Your email address is still your unique identifier for your account."
                     ).format(
                         self.USERNAME
                     )


### PR DESCRIPTION
#### Story Link
[Make account login/registration clearer for new SSO users](https://edlyio.atlassian.net/browse/EDE-334)

#### PR Description
Changes the POST SSO Message and username conflict message

Here are the new messages:

![image](https://user-images.githubusercontent.com/23108499/78659857-84424180-78e5-11ea-9cfb-c5ed6da496b4.png)

![image](https://user-images.githubusercontent.com/23108499/78659865-886e5f00-78e5-11ea-8d5d-8505a97cc80a.png)

#### How to test

```
paver test_system -s cms -t common/djangoapps/student/tests/test_retirement.py

paver test_system -s lms -t common/djangoapps/student/tests/test_retirement.py

paver test_system -s lms -t openedx/core/djangoapps/user_api/tests/test_views.py
```

#### Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Change

#### Checklist before merging:

- [x] Squased
- [ ] Reviewd
