### PR TITLE
Enable search on video transcripts

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -48,7 +48,8 @@ from .transcripts_utils import (
     VideoTranscriptsMixin,
     clean_video_id,
     subs_filename,
-    get_transcript_for_video
+    get_transcript_for_video,
+    get_transcript
 )
 
 from .video_handlers import VideoStudentViewHandlers, VideoStudioViewHandlers
@@ -1040,6 +1041,13 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
 
         if self.sub:
             _update_transcript_for_index()
+        else:
+            try:
+                transcript = get_transcript(self, lang=self.transcript_language, output_format=Transcript.TXT)[0].replace("\n", " ")
+                transcript_index_name = "transcript_{}".format(self.transcript_language)
+                video_body.update({transcript_index_name: transcript})
+            except NotFoundError:
+                pass
 
         # Check to see if there are transcripts in other languages besides default transcript
         if self.transcripts:


### PR DESCRIPTION
#### Story Link
[EDE-324](https://edlyio.atlassian.net/browse/EDE-324)

#### PR Description

Retrieve edX course search results on the base of video-transcripts. 

The edX has changed it's "[Add Transcript](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/video/additional_transcript_options.html#upload-an-sjson-file-deprecated)" scenario but I guess video transcript indexing code didn't get updated.

**Note:** The edX search is a kind of “**one-word search**”. Like if I search for a single word from transcript it is working fine.  But if I search for a line, it will break that line into words and search for all those words separately and then return the first 20 search results.

Sample screenshots are given below:

![image](https://user-images.githubusercontent.com/42185078/78775878-655cb180-79b0-11ea-8783-b70af589cf0e.png)

![image](https://user-images.githubusercontent.com/42185078/78775945-7c9b9f00-79b0-11ea-9fd1-b219c1fbb9b1.png)


#### Type of change

Please select the options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Change


#### Checklist before merging:

- [ ] Squased
- [ ] Reviewd
