### PR TITLE
Update version of xblock-consumer-lti in requirement files

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -21,7 +21,8 @@ git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc8685
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
-git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xblock==1.2.5
+git+https://github.com/appsembler/tahoe-lti.git@release-0.2.0#egg=tahoe-lti==release-0.2.0
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
 git+https://github.com/edx/edx-ora2.git@2.2.0#egg=ora2==2.2.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -24,7 +24,8 @@ git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc8685
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#egg=lettuce==0.2.23+edx.1
-git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xblock==1.2.5
+git+https://github.com/appsembler/tahoe-lti.git@release-0.2.0#egg=tahoe-lti==release-0.2.0
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
 git+https://github.com/edx/edx-ora2.git@2.2.0#egg=ora2==2.2.0

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -70,6 +70,7 @@
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 -e git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
+-e git+https://github.com/appsembler/tahoe-lti.git@release-0.2.0#egg=tahoe-lti==release-0.2.0
 
 # Forked to get Django 1.10+ compat that is in origin BitBucket repo, without an official build.
 # This can go away when we update auth to not use django-rest-framework-oauth
@@ -95,7 +96,7 @@
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
--e git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
+-e git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xblock==1.2.5
 
 # Third Party XBlocks
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -22,7 +22,8 @@ git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc8685
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#egg=lettuce==0.2.23+edx.1
-git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xblock==1.2.5
+git+https://github.com/appsembler/tahoe-lti.git@release-0.2.0#egg=tahoe-lti==release-0.2.0
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
 git+https://github.com/edx/edx-ora2.git@2.2.0#egg=ora2==2.2.0


### PR DESCRIPTION
#### Story Link
[https://edlyio.atlassian.net/browse/EDE-350](https://edlyio.atlassian.net/browse/EDE-350)

#### PR Description

When we try to configure a new LTI tool especially **Perusall** in openedx, it doesn't configure properly. It gives an error. 
![image](https://user-images.githubusercontent.com/42294172/79119559-11840b00-7daa-11ea-8ac4-38c824c7c0ae.png)

The reason for that error is that the current version of **xblock-consumer-lti** (1.1.8 used in ironwood release) doesn't send the required information to **Perusall**.
The required information for **Perusall** includes
![image](https://user-images.githubusercontent.com/42294172/79119093-f49b0800-7da8-11ea-91f9-85d6861e0a6d.png)
And the information sent by **xblock-consumer-lti** includes
![image](https://user-images.githubusercontent.com/42294172/79119147-1a281180-7da9-11ea-8c92-f03fc8662781.png)
 

So, to get this thing work properly. I updated the version of **xblock-consumer-lti** which have added the functionality to add custom processors to send extra information. I also installed a new python package named **tahoe-lti** which includes custom processors responsible to send extra parameters to **LTI providers** like in our case it is **Perusall**

#### Output
![image](https://user-images.githubusercontent.com/42294172/79119617-34162400-7daa-11ea-9762-89809ed593d8.png)
![image](https://user-images.githubusercontent.com/42294172/79119622-37a9ab00-7daa-11ea-9a09-2f207294148e.png)
![image](https://user-images.githubusercontent.com/42294172/79119627-3b3d3200-7daa-11ea-8113-e3830c9283cc.png)

#### Type of change

Please select the options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Change
