### PR TITLE
Fixed LMS_BASE url variable in certificate description

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -97,6 +97,8 @@ def _update_certificate_context(context, course, user_certificate, platform_name
     # Populate dynamic output values using the course/certificate data loaded above
     certificate_type = context.get('certificate_type')
 
+    lms_base = configuration_helpers.get_value("lms_base", settings.LMS_BASE)
+
     # Override the defaults with any mode-specific static values
     context['certificate_id_number'] = user_certificate.verify_uuid
     context['certificate_verify_url'] = "{prefix}{uuid}{suffix}".format(
@@ -139,10 +141,11 @@ def _update_certificate_context(context, course, user_certificate, platform_name
     # edx-417
     context['accomplishment_copy_description_full'] = _("has successfully completed an offering of")
     context['accomplishment_disclaimer'] = _("A Statement of accomplishment acknowledges that a {platform_name} " +
-                                             "course offered on {{ROOT_URL_VARIABLE}} was completed with a score indicating mastery of material by a particular learner. " +
+                                             "course offered on {lms_base} was completed with a score indicating mastery of material by a particular learner. " +
                                              "A Statement of accomplishment is not a certificate.  It does not convey any academic credit, grade or degree, " +
                                              "or indicate enrollment at UC San Diego").format(
-        platform_name=platform_name
+        platform_name=platform_name,
+        lms_base=lms_base
     ).upper()
 
     certificate_type_description = get_certificate_description(user_certificate.mode, certificate_type, platform_name)

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -559,6 +559,7 @@ COMPREHENSIVE_THEME_DIRS = [REPO_ROOT / "themes", REPO_ROOT / "common/test"]
 COMPREHENSIVE_THEME_LOCALE_PATHS = [REPO_ROOT / "themes/conf/locale", ]
 
 LMS_ROOT_URL = "http://localhost:18000"
+LMS_BASE = "localhost:18000"
 
 # TODO (felipemontoya): This key is only needed during lettuce tests.
 # To be removed during https://openedx.atlassian.net/browse/DEPR-19


### PR DESCRIPTION
#### Description:

Fixed the variable used in Certificate Description for `LMS_BASE URL`.