### PR TITLE
EDE-384: Fix Bug "NoneType" object has not backend

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -367,7 +367,7 @@ class AccountCreationForm(forms.Form):
 
     def clean_password(self):
         """Enforce password policies (if applicable)"""
-        password = self.cleaned_data["password"]
+        password = self.data["password"]
         if not self.do_third_party_auth:
             # Creating a temporary user object to test password against username
             # This user should NOT be saved


### PR DESCRIPTION
#### Story Link
[Fix Bug "NoneType" object has not backend](https://edlyio.atlassian.net/browse/EDE-384)

#### PR Description

Fixes a bug where putting `Space` at the start or end of the password occurs Bug "NoneType" object has not backend.

#### Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Change

#### How to test?

While registration of the new users. Enter space at the start or end of the password and check if the user successfully registers.

#### Checklist before merging:

- [ ] Squased
- [ ] Reviewd
