### PR TITLE
Import private.py file in devstack_docker.py instead of devstack.py

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -175,11 +175,6 @@ IDA_LOGOUT_URI_LIST = [
 from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants
 plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.CMS, plugin_constants.SettingsType.DEVSTACK)
 
-###############################################################################
-# See if the developer has any local overrides.
-if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
-    from .private import *  # pylint: disable=import-error,wildcard-import
-
 #####################################################################
 # Lastly, run any migrations, if needed.
 MODULESTORE = convert_module_store_setting_if_needed(MODULESTORE)

--- a/cms/envs/devstack_docker.py
+++ b/cms/envs/devstack_docker.py
@@ -28,3 +28,8 @@ JWT_AUTH.update({
     'JWT_ISSUER': OAUTH_OIDC_ISSUER,
     'JWT_AUDIENCE': 'lms-key',
 })
+
+###############################################################################
+# See if the developer has any local overrides.
+if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
+    from .private import *  # pylint: disable=import-error,wildcard-import

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -265,11 +265,6 @@ from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin
 plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_constants.SettingsType.DEVSTACK)
 
 #####################################################################
-# See if the developer has any local overrides.
-if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
-    from .private import *  # pylint: disable=import-error,wildcard-import
-
-#####################################################################
 # Lastly, run any migrations, if needed.
 MODULESTORE = convert_module_store_setting_if_needed(MODULESTORE)
 

--- a/lms/envs/devstack_docker.py
+++ b/lms/envs/devstack_docker.py
@@ -79,3 +79,8 @@ COURSE_CATALOG_API_URL = 'http://edx.devstack.discovery:18381/api/v1/'
 # Uncomment the lines below if you'd like to see SQL statements in your devstack LMS log.
 # LOGGING['handlers']['console']['level'] = 'DEBUG'
 # LOGGING['loggers']['django.db.backends'] = {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False}
+
+#####################################################################
+# See if the developer has any local overrides.
+if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
+    from .private import *  # pylint: disable=import-error,wildcard-import


### PR DESCRIPTION
Cheryy-picking: https://github.com/edx/edx-platform/pull/23512

#### PR Description

Now that the devstack is dockerized, I think it makes more sense to import the private.py in the devstack_docker.py files i.e. at the end of configuration files hierarchy.