### PR TITLE
revert caliper version back to 0.11.8

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -620,7 +620,6 @@ if FEATURES.get('ENABLE_EVENT_CALIPERIZATION'):
 
     if FEATURES.get('ENABLE_KAFKA_FOR_CALIPER'):
         CALIPER_KAFKA_SETTINGS = ENV_TOKENS.get('CALIPER_KAFKA_SETTINGS')
-        CALIPER_KAFKA_AUTH_SETTINGS = AUTH_TOKENS.get('CALIPER_KAFKA_AUTH_SETTINGS')
 ####################### Plugin Settings ##########################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1150,8 +1150,6 @@ if FEATURES.get('ENABLE_EVENT_CALIPERIZATION'):
 
     if FEATURES.get('ENABLE_KAFKA_FOR_CALIPER'):
         CALIPER_KAFKA_SETTINGS = ENV_TOKENS.get('CALIPER_KAFKA_SETTINGS')
-        CALIPER_KAFKA_AUTH_SETTINGS = AUTH_TOKENS.get('CALIPER_KAFKA_AUTH_SETTINGS')
-
 ############################### Plugin Settings ###############################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -179,7 +179,7 @@ numpy==1.6.2
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2      # via django-rest-swagger
-openedx-caliper-tracking==0.12.1
+openedx-caliper-tracking==0.11.8
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4


### PR DESCRIPTION
#### PR Description
- Revert changes or #371 

**Please note that** this PR needs to be reverted before the next production release since this commit is not in the other (`develop` and `release-candidate`) branches. And therefore while making the next Prod release, there might arise some conflicts.