### PR TITLE
Add option to send events to tracker in segment track events

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -656,7 +656,6 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         go through `add_enrollment()`, which allows creation of new and reactivation of old enrollments.
         """
         # Get the User, Course ID, and Mode from the request.
-
         username = request.data.get('user', request.user.username)
         course_id = request.data.get('course_details', {}).get('course_id')
 

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -656,6 +656,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         go through `add_enrollment()`, which allows creation of new and reactivation of old enrollments.
         """
         # Get the User, Course ID, and Mode from the request.
+
         username = request.data.get('user', request.user.username)
         course_id = request.data.get('course_details', {}).get('course_id')
 

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -649,7 +649,6 @@ def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=Non
 @partial.partial
 def login_analytics(strategy, auth_entry, current_partial=None, *args, **kwargs):
     """ Sends login info to Segment """
-
     event_name = None
     if auth_entry == AUTH_ENTRY_LOGIN:
         event_name = 'edx.bi.user.account.authenticated'
@@ -660,8 +659,9 @@ def login_analytics(strategy, auth_entry, current_partial=None, *args, **kwargs)
         segment.track(kwargs['user'].id, event_name, {
             'category': "conversion",
             'label': None,
-            'provider': kwargs['backend'].name
-        })
+            'provider': kwargs['backend'].name,
+            'username': kwargs.get('username','')
+        }, send_to_track=True, user=kwargs['user'])
 
 
 @partial.partial

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -649,6 +649,7 @@ def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=Non
 @partial.partial
 def login_analytics(strategy, auth_entry, current_partial=None, *args, **kwargs):
     """ Sends login info to Segment """
+
     event_name = None
     if auth_entry == AUTH_ENTRY_LOGIN:
         event_name = 'edx.bi.user.account.authenticated'

--- a/common/djangoapps/track/segment.py
+++ b/common/djangoapps/track/segment.py
@@ -29,8 +29,8 @@ def track(user_id, event_name, properties=None, context=None, send_to_track=Fals
 
         if user and getattr(user, 'username', ''):
             context_override['username'] = user.username
-        else:
-            context_override['user_id'] = user_id
+
+        context_override['user_id'] = user_id
 
         with tracker.get_tracker().context('edx.course.segment', context_override):
             tracker.emit(name=event_name, data=properties)

--- a/common/djangoapps/track/segment.py
+++ b/common/djangoapps/track/segment.py
@@ -11,15 +11,31 @@ To use, call "from track import segment", then call segment.track() or segment.i
 from urlparse import urlunsplit
 
 import analytics
+from crum import get_current_request
 from django.conf import settings
 from eventtracking import tracker
+from track import contexts
+from track.views import _get_request_value
 
 
-def track(user_id, event_name, properties=None, context=None):
+def track(user_id, event_name, properties=None, context=None, send_to_track=False, user=None):
     """Wrapper for emitting Segment track event, including augmenting context information from middleware."""
+    properties = properties or {}
+
+    if event_name is not None and send_to_track:
+        request = get_current_request()
+        page = _get_request_value(request, 'page') or getattr(request, 'path', '')
+        context_override = contexts.course_context_from_url(page)
+
+        if user and getattr(user, 'username', ''):
+            context_override['username'] = user.username
+        else:
+            context_override['user_id'] = user_id
+
+        with tracker.get_tracker().context('edx.course.segment', context_override):
+            tracker.emit(name=event_name, data=properties)
 
     if event_name is not None and hasattr(settings, 'LMS_SEGMENT_KEY') and settings.LMS_SEGMENT_KEY:
-        properties = properties or {}
         segment_context = dict(context) if context else {}
         tracking_context = tracker.get_tracker().resolve_context()
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1463,7 +1463,7 @@ def _track_successful_certificate_generation(user_id, course_id, user=None):
     segment.track(user_id, event_name, {
         'category': 'certificates',
         'label': text_type(course_id)
-    }, send_to_track=True , user=user)
+    }, send_to_track=True, user=user)
 
 
 @require_http_methods(["GET", "POST"])

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1444,11 +1444,11 @@ def generate_user_cert(request, course_id):
         # with a management command.  From the user's perspective,
         # it will appear that the certificate task was submitted successfully.
         certs_api.generate_user_certificates(student, course.id, course=course, generation_mode='self')
-        _track_successful_certificate_generation(student.id, course.id)
+        _track_successful_certificate_generation(student.id, course.id, user=student)
         return HttpResponse()
 
 
-def _track_successful_certificate_generation(user_id, course_id):
+def _track_successful_certificate_generation(user_id, course_id, user=None):
     """
     Track a successful certificate generation event.
 
@@ -1463,7 +1463,7 @@ def _track_successful_certificate_generation(user_id, course_id):
     segment.track(user_id, event_name, {
         'category': 'certificates',
         'label': text_type(course_id)
-    })
+    }, send_to_track=True , user=user)
 
 
 @require_http_methods(["GET", "POST"])

--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -59,6 +59,7 @@ class ResponseNotification(BaseMessageType):
 @task(base=LoggedTask, routing_key=ROUTING_KEY)
 def send_ace_message(context):
     context['course_id'] = CourseKey.from_string(context['course_id'])
+
     if _should_send_message(context):
         context['site'] = Site.objects.get(id=context['site_id'])
         thread_author = User.objects.get(id=context['thread_author_id'])

--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -59,7 +59,6 @@ class ResponseNotification(BaseMessageType):
 @task(base=LoggedTask, routing_key=ROUTING_KEY)
 def send_ace_message(context):
     context['course_id'] = CourseKey.from_string(context['course_id'])
-
     if _should_send_message(context):
         context['site'] = Site.objects.get(id=context['site_id'])
         thread_author = User.objects.get(id=context['thread_author_id'])
@@ -101,7 +100,8 @@ def _track_notification_sent(message, context):
         segment.track(
             user_id=context['thread_author_id'],
             event_name='edx.bi.email.sent',
-            properties=properties
+            properties=properties,
+            send_to_track=True
         )
 
 

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -677,10 +677,10 @@ def permalink(content):
     else:
         course_id = content['course_id']
     if content['type'] == 'thread':
-        return reverse('discussion.views.single_thread',
+        return reverse('single_thread',
                        args=[course_id, content['commentable_id'], content['id']])
     else:
-        return reverse('discussion.views.single_thread',
+        return reverse('single_thread',
                        args=[course_id, content['commentable_id'], content['thread_id']]) + '#' + content['id']
 
 

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.db import connection
 from django.http import HttpResponse
 from pytz import UTC
@@ -677,11 +677,19 @@ def permalink(content):
     else:
         course_id = content['course_id']
     if content['type'] == 'thread':
-        return reverse('single_thread',
-                       args=[course_id, content['commentable_id'], content['id']])
+        try:
+            return reverse('discussion.views.single_thread',
+                            args=[course_id, content['commentable_id'], content['id']])
+        except NoReverseMatch:
+            return reverse('single_thread',
+                            args=[course_id, content['commentable_id'], content['id']])
     else:
-        return reverse('single_thread',
-                       args=[course_id, content['commentable_id'], content['thread_id']]) + '#' + content['id']
+        try:
+            return reverse('discussion.views.single_thread',
+                           args=[course_id, content['commentable_id'], content['thread_id']]) + '#' + content['id']
+        except NoReverseMatch:
+            return reverse('single_thread',
+                           args=[course_id, content['commentable_id'], content['thread_id']]) + '#' + content['id']
 
 
 def extend_content(content):

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -529,7 +529,7 @@ class Order(models.Model):
                 'revenue': str(self.total_cost),
                 'currency': self.currency,
                 'products': [item.analytics_data() for item in orderitems]
-            })
+            }, send_to_track=True, user=user)
 
         except Exception:  # pylint: disable=broad-except
             # Capturing all exceptions thrown while tracking analytics events. We do not want

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1096,7 +1096,7 @@ class SubmitPhotosView(View):
         Returns: None
 
         """
-        segment.track(user.id, event_name, parameters)
+        segment.track(user.id, event_name, parameters, user=user, send_to_track=True)
 
 
 @require_POST

--- a/openedx/core/djangoapps/schedules/signals.py
+++ b/openedx/core/djangoapps/schedules/signals.py
@@ -144,7 +144,9 @@ def _should_randomly_suppress_schedule_creation(
                 'experience_type': experience_type,
                 'upgrade_deadline': upgrade_deadline_str,
                 'content_availability_date': content_availability_date.isoformat(),
-            }
+            },
+            user=enrollment.user,
+            send_to_track=True
         )
         return True
 

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -243,6 +243,7 @@ def _track_message_sent(site, user, msg):
             user_id=user.id,
             event_name='edx.bi.email.sent',
             properties=properties,
+            send_to_track=True
         )
 
 

--- a/openedx/core/djangoapps/user_api/preferences/api.py
+++ b/openedx/core/djangoapps/user_api/preferences/api.py
@@ -264,8 +264,7 @@ def update_email_opt_in(user, org, opt_in):
     preference.value = str(opt_in)
     try:
         preference.save()
-        if hasattr(settings, 'LMS_SEGMENT_KEY') and settings.LMS_SEGMENT_KEY:
-            _track_update_email_opt_in(user.id, org, opt_in)
+        _track_update_email_opt_in(user.id, org, opt_in)
     except IntegrityError as err:
         log.warning(u"Could not update organization wide preference due to IntegrityError: {}".format(text_type(err)))
 
@@ -290,6 +289,7 @@ def _track_update_email_opt_in(user_id, organization, opt_in):
             'category': 'communication',
             'label': organization
         },
+        send_to_track=True
     )
 
 

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -281,8 +281,12 @@ def _track_user_login(user, request):
         {
             'category': "conversion",
             'label': request.POST.get('course_id'),
-            'provider': None
+            'provider': None,
+            'email': request.POST.get('email'),
+            'username': user.username
         },
+        send_to_track=True,
+        user=user
     )
 
 

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -336,15 +336,20 @@ def _track_user_registration(user, profile, params, third_party_provider):
             })
 
         segment.identify(*identity_args)
-        segment.track(
-            user.id,
-            "edx.bi.user.account.registered",
-            {
-                'category': 'conversion',
-                'label': params.get('course_id'),
-                'provider': third_party_provider.name if third_party_provider else None
-            },
-        )
+
+    # Moving this outside the if block. `LMS_SEGMENT_KEY` check will be handled
+    # inside the track method.
+    segment.track(
+        user.id,
+        "edx.bi.user.account.registered",
+        {
+            'category': 'conversion',
+            'label': params.get('course_id'),
+            'provider': third_party_provider.name if third_party_provider else None
+        },
+        user=user,
+        send_to_track=True
+    )
 
 
 def _skip_activation_email(user, do_external_auth, running_pipeline, third_party_provider):


### PR DESCRIPTION
#### Story Link
https://edlyio.atlassian.net/browse/EDE-628

#### PR Description
Right now a few events (edx.bi.*, Refunded Order and Completed Order) are emitted through segment.track call. These events go directly to segment.com, if configured, which we haven’t.
We need to customize the edx-platform in such a way that these events are passed through segment track as well as the standard django tracker.


The complete list of such events is as follows:

- edx.bi.user.account.authenticated
- edx.bi.user.account.linked
- edx.bi.user.certificate.generate
- edx.bi.email.sent
- edx.bi.verify.submitted
- edx.bi.schedule.suppressed
- edx.bi.user.org_email.opted_in
- edx.bi.user.org_email.opted_out
- edx.bi.user.account.registered
- Refunded Order
- Completed Order


`Refunded Order` and `Completed Order` couldn't be generated in the payment and refund flow (tried the edx's flow and e-commerce's client-side flow.)

It seems that there events are not generated in our scenario. Code is put in the place to track these events if they are ever generated but we won't be writing transformer for these events as current event format is unknown.