### PR TITLE
Update openedx-caliper-tracking version to 0.14.2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -179,7 +179,7 @@ numpy==1.6.2
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2      # via django-rest-swagger
-openedx-caliper-tracking==0.14.1
+openedx-caliper-tracking==0.14.2
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4


### PR DESCRIPTION
#### Story Link
https://edlyio.atlassian.net/browse/EDE-772

#### PR Description
Update openedx-caliper-tracking `0.14.2` 