### PR TITLE
Edx.bi.* event generation

### DIFF
--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -72,10 +72,10 @@ def send_ace_message(context):
             )
             log.info('Sending forum comment email notification with context %s', message_context)
             ace.send(message)
-            _track_notification_sent(message, context)
+            _track_notification_sent(message, context, thread_author)
 
 
-def _track_notification_sent(message, context):
+def _track_notification_sent(message, context, user):
     """
     Send analytics event for a sent email
     """
@@ -102,7 +102,8 @@ def _track_notification_sent(message, context):
             user_id=context['thread_author_id'],
             event_name='edx.bi.email.sent',
             properties=properties,
-            send_to_track=True
+            send_to_track=True,
+            user=user
         )
 
 

--- a/lms/djangoapps/discussion/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/tests/test_tasks.py
@@ -313,6 +313,12 @@ class TaskTestCase(ModuleStoreTestCase):
     ))
     @ddt.unpack
     def test_track_notification_sent(self, context, test_props):
+        thread_author = UserFactory(
+            username='a_fake_dude2',
+            password='password',
+            email='email'
+        )
+
         with mock.patch('edx_ace.ace.send').start() as message:
             # Populate mock message (
             # There are some cruft attrs, but they're harmless.
@@ -324,10 +330,11 @@ class TaskTestCase(ModuleStoreTestCase):
             site = Site.objects.get_current()
             context['site'] = site
             with mock.patch('lms.djangoapps.discussion.tasks.segment.track') as mock_segment_track:
-                _track_notification_sent(message, context)
+                _track_notification_sent(message, context, thread_author)
                 mock_segment_track.assert_called_once_with(
                     user_id=context['thread_author_id'],
                     event_name='edx.bi.email.sent',
                     properties=test_props,
-                    send_to_track=True
+                    send_to_track=True,
+                    user=thread_author
                 )

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -243,7 +243,8 @@ def _track_message_sent(site, user, msg):
             user_id=user.id,
             event_name='edx.bi.email.sent',
             properties=properties,
-            send_to_track=True
+            send_to_track=True,
+            user=user
         )
 
 


### PR DESCRIPTION
#### Story Link
[EDE-824](https://edlyio.atlassian.net/browse/EDE-824)

#### PR Description

**edx.bi.email.sent** 

Can be generated by enabling the notification. After you have set up ACE and the third party email client, you enable discussion notifications in the Django administration console for your instance of Open edX.

- Sign in to the LMS Django administration console 
- On the Site Administration page, locate Site_Configuration.
- In the Site_Configuration section, next to Site configurations, select Change.
- On the Change site configuration page, locate the Values field, and then add the following value.
- `{"enable_forum_notifications":true}`
- Select Save.

The scenario of generation: when you have enabled the above flag and On your post, someone else comment for the first time and update the schedule and get its notification via email. 

![image](https://user-images.githubusercontent.com/30313791/91726343-83be8600-ebb9-11ea-9bfa-985334c950db.png)


————————————————————————————————————————————————————————— 

**edx.bi.schedule.suppressed**

Can be generated by enabling the `create_schedules_for_course` flag in adding by 

- Sign in to the LMS Django administration console 
- On the Site Administration page, locate `Waffle_Utils`.
- In Waffle_Utils section, select `Waffle flag override`
- add `schedules.create_schedules_for_course` flag with the particular course you want to enable this event. 
- On the Site Administration page, locate `SCHEDULES` section 
- In schedules, section go in the `schedule configs`
- Put any ratio greater than 0 and lesser than 1 to randomize the scheduling of enrollment. 
- In the `Instructor` section on LMS of that particular course, select `Membership` tab, and when the staff/instructor sends a request to enroll people and then they create the user on the invite and enroll in that particular course than this event is triggered. 

![image](https://user-images.githubusercontent.com/30313791/91726610-ff203780-ebb9-11ea-905c-0b302d1c56fc.png)

—————————————————————————————————————————————————————————

**edx.bi.user.org_email.opted_in
edx.bi.user.org_email.opted_out**

read the docs and explored the options but unable to find the setting to turn on Organization email, and also not getting the email preference on the course enrollment as mentioned on docs. Read this below it says it's only available on edx.org 

![image](https://user-images.githubusercontent.com/30313791/91726781-3c84c500-ebba-11ea-8ee7-fa985ff6d140.png)


————————————————————————————————————————————————————————— 

**edx.course.goal.added**

- Sign in to the LMS Django administration console 
- On the Site Administration page, locate Waffle_Utils.
- In Waffle_Utils section, select Waffle flag override
- add course_experience.enable_course_goals flag with the particular course you want to enable this event. 
- Sign in the Ecommerce Site on URL <Ecommerce>/courses e:g http://localhost:18130/courses/ and click Add new Course and add that particular course with its details, choose course type as verified. 
- Enroll in that course and hence you will see the Course Goal Info such as

![image](https://user-images.githubusercontent.com/30313791/91726865-5a522a00-ebba-11ea-9473-0d7fa816f37c.png)

register your first goal and hence it will be generated as added 

![image](https://user-images.githubusercontent.com/30313791/91726921-6b02a000-ebba-11ea-9370-5945430f8910.png)

—————————————————————————————————————————————————————————

**edx.course.goal.updated**

> - Sign in to the LMS Django administration console 
> - On the Site Administration page, locate Waffle_Utils.
> - In Waffle_Utils section, select Waffle flag override
> - add course_experience.enable_course_goals flag with the particular course you want to enable this event. 
> - Sign in the Ecommerce Site on URL <Ecommerce>/courses e:g http://localhost:18130/courses/ and click Add new Course and add that particular course with its details, choose course type as verified. 
> - Enroll in that course and hence you will see the Course Goal Info

- Need to update the set Goal to something else and the event will generate as such

![image](https://user-images.githubusercontent.com/30313791/91727064-95545d80-ebba-11ea-8dad-f7b8180c965c.png)

