### PR TITLE
add to bulk email context in celery task

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -188,7 +188,7 @@ def perform_delegate_email_batches(entry_id, course_id, task_input, action_name)
     # context as per the provided site, otherwise simply get the email
     # context.
     try:
-        with emulate_http_request(site=Site.objects.get(id=site_id)):
+        with emulate_http_request(site=Site.objects.get(id=site_id), user=entry.requester):
             global_email_context = _get_course_email_context(course)
     except Site.DoesNotExist:
         global_email_context = _get_course_email_context(course)

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -314,7 +314,7 @@ def submit_bulk_course_email(request, course_key, email_id):
 
     task_type = 'bulk_course_email'
     task_class = send_bulk_course_email
-    task_input = {'email_id': email_id, 'to_option': targets}
+    task_input = {'email_id': email_id, 'to_option': targets, 'site': request.site.id}
     task_key_stub = str(email_id)
     # create the key value by using MD5 hash:
     task_key = hashlib.md5(task_key_stub).hexdigest()

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -249,9 +249,11 @@ class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCa
             api_call()
 
     def test_submit_bulk_email_all(self):
+        request = self.create_task_request(self.instructor)
+        request.site.id = None
         email_id = self._define_course_email()
         api_call = lambda: submit_bulk_course_email(
-            self.create_task_request(self.instructor),
+            request,
             self.course.id,
             email_id
         )


### PR DESCRIPTION
#### Story Link
https://edlyio.atlassian.net/browse/EDE-876

#### PR Description

Bulk emails are sent from the celery workers and thus there is no request object for getting the site configurations. We need to send site information in the task input and get the site in the celery task.

#### Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Change
