### PR TITLE
change html align left to css float left

### DIFF
--- a/common/lib/xmodule/xmodule/templates/about/overview.yaml
+++ b/common/lib/xmodule/xmodule/templates/about/overview.yaml
@@ -19,7 +19,7 @@ data: |
       <h2>Course Staff</h2>
       <article class="teacher">
         <div class="teacher-image">
-          <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #1">
+          <img src="/static/images/placeholder-faculty.png" style="float:left; margin:0 20 px 0" alt="Course Staff Image #1">
         </div>
 
         <h3>Staff Member #1</h3>
@@ -28,7 +28,7 @@ data: |
 
       <article class="teacher">
         <div class="teacher-image">
-          <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #2">
+          <img src="/static/images/placeholder-faculty.png" style="float:left; margin:0 20 px 0" alt="Course Staff Image #2">
         </div>
 
         <h3>Staff Member #2</h3>


### PR DESCRIPTION
#### Story Link
None
#### PR Description

Studio course overview default html editor content uses align=left; SiteImprove complaining.  Replace with inline css.

#### Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Change

#### How to test?


#### Checklist before merging:

- [ ] Squased
- [ ] Reviewd
