### PR TITLE
Don't emit logout event for already anonymous user

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -56,7 +56,6 @@ class LogoutView(TemplateView):
         # Get the list of authorized clients before we clear the session.
         self.oauth_client_ids = request.session.get(edx_oauth2_provider.constants.AUTHORIZED_CLIENTS_SESSION_KEY, [])
 
-        # if tests are giving Anonymous User objects
         event_data = {}
         if not request.user.is_anonymous:
             event_data = {
@@ -67,7 +66,10 @@ class LogoutView(TemplateView):
 
         logout(request)
 
-        if request.user.is_anonymous:
+        # `event_data` will be empty if the user was anonymous even before
+        # the `logout` call. don't emit event if an anonymous user has hit
+        # the logout URL.
+        if request.user.is_anonymous and event_data:
             event_name = 'edx.user.logout'
             tracker.emit(event_name, event_data)
 


### PR DESCRIPTION
#### Story Link
https://edlyio.atlassian.net/browse/EDE-917

#### PR Description

Check if user was actually logged in before hitting the logout URL. Only then emit the logout event.

#### Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Change
