### PR TITLE
Add package to ucsd_features to read a list of redirects from the con…

### DIFF
--- a/openedx/features/ucsd_features/apps.py
+++ b/openedx/features/ucsd_features/apps.py
@@ -8,3 +8,4 @@ class UcsdFeatures(AppConfig):
         super(UcsdFeatures, self).ready()
         from openedx.features.ucsd_features.signals import *
         from openedx.features.ucsd_features.additional_registration_fields import *
+        from openedx.features.ucsd_features.redirects import *

--- a/openedx/features/ucsd_features/redirects.py
+++ b/openedx/features/ucsd_features/redirects.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.conf.urls import url
+from django.shortcuts import redirect
+
+from logging import getLogger
+
+# Import the URL configuration module for the current environment
+import importlib
+urls = importlib.import_module(settings.ROOT_URLCONF)
+
+log = getLogger(__name__)
+
+def callback_generator(destination):
+    def callback(request):
+        return redirect(destination)
+    return callback
+
+patterns = []
+if hasattr(settings, "ENV_TOKENS"):
+    patterns = settings.ENV_TOKENS.get("UCSD_REDIRECT_URLS", [])
+
+# Iterate in reverse order, so that the first redirect listeed ends up in the first element of the URL Patterns array
+for pattern in patterns[::-1]:
+    log.info("Redirecting route {} to {}".format(pattern['route'], pattern['dest']))
+
+    # A request is handled by the first matching route, so these overrides must be prepended
+    urls.urlpatterns.insert(0, url(pattern['route'], callback_generator(pattern['dest'])))

--- a/openedx/features/ucsd_features/redirects.py
+++ b/openedx/features/ucsd_features/redirects.py
@@ -10,6 +10,7 @@ urls = importlib.import_module(settings.ROOT_URLCONF)
 
 log = getLogger(__name__)
 
+
 def callback_generator(destination):
     def callback(request):
         return redirect(destination)


### PR DESCRIPTION
Adds a mechanism to configure static redirects from a route, which will take precedence over any URL routes configured in {lms,cms}/urls.py

#### Story Link

As a marketing staff who has published advertising with an incorrect link, I would like for potential customers who find and click that link to be taken to their correct destination

#### PR Description

Adds a class under ucsd_features which checks the LMS env for one or more UCSD_REDIRECT_URLs, and if found, prepends a callback to lms/urls.py's urlpatterns that renders a redirect view to that destination. 

#### Type of change

Please select the options that are relevant.

- New feature (non-breaking change which adds functionality)

#### How to test?

Modify lms.env.json to include:

    "UCSD_REDIRECT_URLS": [
                { "route": "^courses/course-v1:edx\\+demox\\+demo_course/about", "dest": "/courses/course-v1:edX+DemoX+Demo_Course/about#plain" }
                ],

Fetch that path, and verify that the response redirects to the correct location:

 % curl --head --silent 'https://learnx-devstack.ucsd.edu:18000/courses/course-v1:edx+demox+demo_course/about' | grep Location
 Location: /courses/course-v1:edX+DemoX+Demo_Course/about#plain

#### Checklist before merging:

- [ ] Squashed
- [ ] Reviewed
